### PR TITLE
sponsorship: update sponsors 🙏

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ And please give some love to our featured sponsors 🤩:
 <td align="center"><a href="https://storyscript.com/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Story.ai" /><br />Story.ai</a> *</td>
 <td align="center"><a href="http://chads.website"><img src="https://graphile.org/images/sponsors/chadf.png" width="90" height="90" alt="Chad Furman" /><br />Chad Furman</a> *</td>
 <td align="center"><a href="https://www.the-guild.dev/"><img src="https://graphile.org/images/sponsors/theguild.png" width="90" height="90" alt="The Guild" /><br />The Guild</a> *</td>
+</tr><tr>
 <td align="center"><a href="https://www.fanatics.com/"><img src="https://graphile.org/images/sponsors/fanatics.png" width="90" height="90" alt="Fanatics" /><br />Fanatics</a> *</td>
 <td align="center"><a href="https://www.enzuzo.com/"><img src="https://graphile.org/images/sponsors/enzuzo.png" width="90" height="90" alt="Enzuzo" /><br />Enzuzo</a> *</td>
-<td align="center"><a href="https://politicsrewired.com/"><img src="https://graphile.org/images/sponsors/politics-rewired.png" width="90" height="90" alt="Politics Rewired" /><br />Politics Rewired</a></td>
 </tr></table>
 
 <em>\* Sponsors the entire Graphile suite</em>

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -6,49 +6,63 @@ Graphile ecosystem. Find out
 
 ## Featured
 
+- Surge
+- Story.ai
 - Chad Furman
-- Storyscript
-- Postlight
+- The Guild
+- Fanatics
+- Enzuzo
 
 ## Leaders
 
-- Joe Dennis
-- domonda
 - Robert Claypool
-- James Allain
-- Stagency
-- Jack Dinker
-- 8th Light
-- Nigel Taylor
-- DocIQ
-- Principia Mentis
+- Joe Dennis
 - Qwick
-- Partners in School Innovation
-- OpenLaw NZ
-- Sterblue
+- domonda
+- Jack Dinker
+- DocIQ
+- nigelrmtaylor
+- Politics Rewired
+- Principia Mentis
 - HR-ON
-- Ian Stewart
-- Janakan Arulkumarasan
+- Luxor Labs
+- Dovetail
+- PostHog
+- Taiste
+- Axinom
+- Notably
+- Nathanael Beisiegel
+- William Baxter
+- SuperRare Labs
+- latch.bio
 
 ## Supporters
 
-- Daniel Einspanjer
+- Postlight
+- Philipp Litzenberger
 - Sam Levin
-- stlbucket
 - Matt Bretl
 - Chris Watland
+- Mark
+- svarmony
+- Simon Elliott
 - James Rascoe
-- Mark Lipscombe
-- Michel Pelletier
-- Frank
-- Mark Rapoza
-- innovation.rocks
-- cybere
-- Daniel Woelfel
-- Philipp Litzenberger
-- Bjørn Michelsen
-- CJ
-- Ben Botwin
-- Cameron Ellis
+- CJ Lazell
 - Mansoor Razzaq
-- Borut Jures
+- Jimmy Liu
+- Keith Layne
+- Olli Selamaa
+- Paul Melnikow
+- Alvin Ali Khaled
+- Dani Kenan
+- Stéphane Klein
+- Splitgraph
+- Kadi Kraman
+- Andrew Poland
+- OnThisSpot
+- Benjamin Berman
+- Zymego
+- ARK
+- Sen Palanisami
+- nick
+- CartoLab

--- a/packages/eslint-plugin-graphile-exporter/README.md
+++ b/packages/eslint-plugin-graphile-exporter/README.md
@@ -22,9 +22,13 @@ and development via sponsorship.
 And please give some love to our featured sponsors 🤩:
 
 <table><tr>
+<td align="center"><a href="https://surge.io/"><img src="https://graphile.org/images/sponsors/surge.png" width="90" height="90" alt="Surge" /><br />Surge</a> *</td>
+<td align="center"><a href="https://storyscript.com/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Story.ai" /><br />Story.ai</a> *</td>
 <td align="center"><a href="http://chads.website"><img src="https://graphile.org/images/sponsors/chadf.png" width="90" height="90" alt="Chad Furman" /><br />Chad Furman</a> *</td>
-<td align="center"><a href="https://storyscript.io/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Storyscript" /><br />Storyscript</a> *</td>
-<td align="center"><a href="https://postlight.com/?utm_source=graphile"><img src="https://graphile.org/images/sponsors/postlight.png" width="90" height="90" alt="Postlight" /><br />Postlight</a> *</td>
+<td align="center"><a href="https://www.the-guild.dev/"><img src="https://graphile.org/images/sponsors/theguild.png" width="90" height="90" alt="The Guild" /><br />The Guild</a> *</td>
+</tr><tr>
+<td align="center"><a href="https://www.fanatics.com/"><img src="https://graphile.org/images/sponsors/fanatics.png" width="90" height="90" alt="Fanatics" /><br />Fanatics</a> *</td>
+<td align="center"><a href="https://www.enzuzo.com/"><img src="https://graphile.org/images/sponsors/enzuzo.png" width="90" height="90" alt="Enzuzo" /><br />Enzuzo</a> *</td>
 </tr></table>
 
 <em>\* Sponsors the entire Graphile suite</em>

--- a/packages/eslint-plugin-graphile-exporter/SPONSORS.md
+++ b/packages/eslint-plugin-graphile-exporter/SPONSORS.md
@@ -6,49 +6,63 @@ Graphile ecosystem. Find out
 
 ## Featured
 
+- Surge
+- Story.ai
 - Chad Furman
-- Storyscript
-- Postlight
+- The Guild
+- Fanatics
+- Enzuzo
 
 ## Leaders
 
-- Joe Dennis
-- domonda
 - Robert Claypool
-- James Allain
-- Stagency
-- Jack Dinker
-- 8th Light
-- Nigel Taylor
-- DocIQ
-- Principia Mentis
+- Joe Dennis
 - Qwick
-- Partners in School Innovation
-- OpenLaw NZ
-- Sterblue
+- domonda
+- Jack Dinker
+- DocIQ
+- nigelrmtaylor
+- Politics Rewired
+- Principia Mentis
 - HR-ON
-- Ian Stewart
-- Janakan Arulkumarasan
+- Luxor Labs
+- Dovetail
+- PostHog
+- Taiste
+- Axinom
+- Notably
+- Nathanael Beisiegel
+- William Baxter
+- SuperRare Labs
+- latch.bio
 
 ## Supporters
 
-- Daniel Einspanjer
+- Postlight
+- Philipp Litzenberger
 - Sam Levin
-- stlbucket
 - Matt Bretl
 - Chris Watland
+- Mark
+- svarmony
+- Simon Elliott
 - James Rascoe
-- Mark Lipscombe
-- Michel Pelletier
-- Frank
-- Mark Rapoza
-- innovation.rocks
-- cybere
-- Daniel Woelfel
-- Philipp Litzenberger
-- Bjørn Michelsen
-- CJ
-- Ben Botwin
-- Cameron Ellis
+- CJ Lazell
 - Mansoor Razzaq
-- Borut Jures
+- Jimmy Liu
+- Keith Layne
+- Olli Selamaa
+- Paul Melnikow
+- Alvin Ali Khaled
+- Dani Kenan
+- Stéphane Klein
+- Splitgraph
+- Kadi Kraman
+- Andrew Poland
+- OnThisSpot
+- Benjamin Berman
+- Zymego
+- ARK
+- Sen Palanisami
+- nick
+- CartoLab

--- a/packages/graphile-build-pg/README.md
+++ b/packages/graphile-build-pg/README.md
@@ -34,11 +34,13 @@ and development via sponsorship.
 And please give some love to our featured sponsors 🤩:
 
 <table><tr>
-<td align="center"><a href="https://storyscript.com/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Story.ai" /><br />Story.ai</a> *</td>
 <td align="center"><a href="https://surge.io/"><img src="https://graphile.org/images/sponsors/surge.png" width="90" height="90" alt="Surge" /><br />Surge</a> *</td>
+<td align="center"><a href="https://storyscript.com/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Story.ai" /><br />Story.ai</a> *</td>
 <td align="center"><a href="http://chads.website"><img src="https://graphile.org/images/sponsors/chadf.png" width="90" height="90" alt="Chad Furman" /><br />Chad Furman</a> *</td>
-<td align="center"><a href="https://postlight.com/?utm_source=graphile"><img src="https://graphile.org/images/sponsors/postlight.jpg" width="90" height="90" alt="Postlight" /><br />Postlight</a> *</td>
-<td align="center"><a href="https://openbase.com/"><img src="https://graphile.org/images/sponsors/openbase.png" width="90" height="90" alt="Openbase" /><br />Openbase</a> *</td>
+<td align="center"><a href="https://www.the-guild.dev/"><img src="https://graphile.org/images/sponsors/theguild.png" width="90" height="90" alt="The Guild" /><br />The Guild</a> *</td>
+</tr><tr>
+<td align="center"><a href="https://www.fanatics.com/"><img src="https://graphile.org/images/sponsors/fanatics.png" width="90" height="90" alt="Fanatics" /><br />Fanatics</a> *</td>
+<td align="center"><a href="https://www.enzuzo.com/"><img src="https://graphile.org/images/sponsors/enzuzo.png" width="90" height="90" alt="Enzuzo" /><br />Enzuzo</a> *</td>
 </tr></table>
 
 <em>\* Sponsors the entire Graphile suite</em>

--- a/packages/graphile-build-pg/SPONSORS.md
+++ b/packages/graphile-build-pg/SPONSORS.md
@@ -6,58 +6,63 @@ Graphile ecosystem. Find out
 
 ## Featured
 
-- Story.ai
 - Surge
+- Story.ai
 - Chad Furman
-- Postlight
-- Openbase
+- The Guild
+- Fanatics
+- Enzuzo
 
 ## Leaders
 
-- Qwick
-- Joe Dennis
 - Robert Claypool
+- Joe Dennis
+- Qwick
 - domonda
 - Jack Dinker
-- nigelrmtaylor
 - DocIQ
+- nigelrmtaylor
 - Politics Rewired
 - Principia Mentis
-- Cameron Ellis
 - HR-ON
-- Ian Stewart
 - Luxor Labs
-- Qloo
-- Axinom
-- Taiste
-- William Baxter
+- Dovetail
 - PostHog
+- Taiste
+- Axinom
 - Notably
 - Nathanael Beisiegel
+- William Baxter
+- SuperRare Labs
+- latch.bio
 
 ## Supporters
 
+- Postlight
+- Philipp Litzenberger
 - Sam Levin
 - Matt Bretl
-- Philipp Litzenberger
 - Chris Watland
 - Mark
-- innovation.rocks
-- James Rascoe
+- svarmony
 - Simon Elliott
+- James Rascoe
 - CJ Lazell
 - Mansoor Razzaq
-- Alvin Ali Khaled
-- Andrew Poland
+- Jimmy Liu
 - Keith Layne
 - Olli Selamaa
 - Paul Melnikow
+- Alvin Ali Khaled
 - Dani Kenan
-- Benjamin Berman
-- Jimmy Liu
+- Stéphane Klein
 - Splitgraph
 - Kadi Kraman
-- Stéphane Klein
+- Andrew Poland
 - OnThisSpot
+- Benjamin Berman
 - Zymego
 - ARK
+- Sen Palanisami
+- nick
+- CartoLab

--- a/packages/graphile-build/README.md
+++ b/packages/graphile-build/README.md
@@ -37,9 +37,13 @@ and development via sponsorship.
 And please give some love to our featured sponsors 🤩:
 
 <table><tr>
+<td align="center"><a href="https://surge.io/"><img src="https://graphile.org/images/sponsors/surge.png" width="90" height="90" alt="Surge" /><br />Surge</a> *</td>
+<td align="center"><a href="https://storyscript.com/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Story.ai" /><br />Story.ai</a> *</td>
 <td align="center"><a href="http://chads.website"><img src="https://graphile.org/images/sponsors/chadf.png" width="90" height="90" alt="Chad Furman" /><br />Chad Furman</a> *</td>
-<td align="center"><a href="https://storyscript.io/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Storyscript" /><br />Storyscript</a> *</td>
-<td align="center"><a href="https://postlight.com/?utm_source=graphile"><img src="https://graphile.org/images/sponsors/postlight.png" width="90" height="90" alt="Postlight" /><br />Postlight</a> *</td>
+<td align="center"><a href="https://www.the-guild.dev/"><img src="https://graphile.org/images/sponsors/theguild.png" width="90" height="90" alt="The Guild" /><br />The Guild</a> *</td>
+</tr><tr>
+<td align="center"><a href="https://www.fanatics.com/"><img src="https://graphile.org/images/sponsors/fanatics.png" width="90" height="90" alt="Fanatics" /><br />Fanatics</a> *</td>
+<td align="center"><a href="https://www.enzuzo.com/"><img src="https://graphile.org/images/sponsors/enzuzo.png" width="90" height="90" alt="Enzuzo" /><br />Enzuzo</a> *</td>
 </tr></table>
 
 <em>\* Sponsors the entire Graphile suite</em>

--- a/packages/graphile-build/SPONSORS.md
+++ b/packages/graphile-build/SPONSORS.md
@@ -6,49 +6,63 @@ Graphile ecosystem. Find out
 
 ## Featured
 
+- Surge
+- Story.ai
 - Chad Furman
-- Storyscript
-- Postlight
+- The Guild
+- Fanatics
+- Enzuzo
 
 ## Leaders
 
-- Joe Dennis
-- domonda
 - Robert Claypool
-- James Allain
-- Stagency
-- Jack Dinker
-- 8th Light
-- Nigel Taylor
-- DocIQ
-- Principia Mentis
+- Joe Dennis
 - Qwick
-- Partners in School Innovation
-- OpenLaw NZ
-- Sterblue
+- domonda
+- Jack Dinker
+- DocIQ
+- nigelrmtaylor
+- Politics Rewired
+- Principia Mentis
 - HR-ON
-- Ian Stewart
-- Janakan Arulkumarasan
+- Luxor Labs
+- Dovetail
+- PostHog
+- Taiste
+- Axinom
+- Notably
+- Nathanael Beisiegel
+- William Baxter
+- SuperRare Labs
+- latch.bio
 
 ## Supporters
 
-- Daniel Einspanjer
+- Postlight
+- Philipp Litzenberger
 - Sam Levin
-- stlbucket
 - Matt Bretl
 - Chris Watland
+- Mark
+- svarmony
+- Simon Elliott
 - James Rascoe
-- Mark Lipscombe
-- Michel Pelletier
-- Frank
-- Mark Rapoza
-- innovation.rocks
-- cybere
-- Daniel Woelfel
-- Philipp Litzenberger
-- Bjørn Michelsen
-- CJ
-- Ben Botwin
-- Cameron Ellis
+- CJ Lazell
 - Mansoor Razzaq
-- Borut Jures
+- Jimmy Liu
+- Keith Layne
+- Olli Selamaa
+- Paul Melnikow
+- Alvin Ali Khaled
+- Dani Kenan
+- Stéphane Klein
+- Splitgraph
+- Kadi Kraman
+- Andrew Poland
+- OnThisSpot
+- Benjamin Berman
+- Zymego
+- ARK
+- Sen Palanisami
+- nick
+- CartoLab

--- a/packages/graphile-exporter/README.md
+++ b/packages/graphile-exporter/README.md
@@ -38,9 +38,13 @@ and development via sponsorship.
 And please give some love to our featured sponsors 🤩:
 
 <table><tr>
+<td align="center"><a href="https://surge.io/"><img src="https://graphile.org/images/sponsors/surge.png" width="90" height="90" alt="Surge" /><br />Surge</a> *</td>
+<td align="center"><a href="https://storyscript.com/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Story.ai" /><br />Story.ai</a> *</td>
 <td align="center"><a href="http://chads.website"><img src="https://graphile.org/images/sponsors/chadf.png" width="90" height="90" alt="Chad Furman" /><br />Chad Furman</a> *</td>
-<td align="center"><a href="https://storyscript.io/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Storyscript" /><br />Storyscript</a> *</td>
-<td align="center"><a href="https://postlight.com/?utm_source=graphile"><img src="https://graphile.org/images/sponsors/postlight.png" width="90" height="90" alt="Postlight" /><br />Postlight</a> *</td>
+<td align="center"><a href="https://www.the-guild.dev/"><img src="https://graphile.org/images/sponsors/theguild.png" width="90" height="90" alt="The Guild" /><br />The Guild</a> *</td>
+</tr><tr>
+<td align="center"><a href="https://www.fanatics.com/"><img src="https://graphile.org/images/sponsors/fanatics.png" width="90" height="90" alt="Fanatics" /><br />Fanatics</a> *</td>
+<td align="center"><a href="https://www.enzuzo.com/"><img src="https://graphile.org/images/sponsors/enzuzo.png" width="90" height="90" alt="Enzuzo" /><br />Enzuzo</a> *</td>
 </tr></table>
 
 <em>\* Sponsors the entire Graphile suite</em>

--- a/packages/graphile-exporter/SPONSORS.md
+++ b/packages/graphile-exporter/SPONSORS.md
@@ -6,49 +6,63 @@ Graphile ecosystem. Find out
 
 ## Featured
 
+- Surge
+- Story.ai
 - Chad Furman
-- Storyscript
-- Postlight
+- The Guild
+- Fanatics
+- Enzuzo
 
 ## Leaders
 
-- Joe Dennis
-- domonda
 - Robert Claypool
-- James Allain
-- Stagency
-- Jack Dinker
-- 8th Light
-- Nigel Taylor
-- DocIQ
-- Principia Mentis
+- Joe Dennis
 - Qwick
-- Partners in School Innovation
-- OpenLaw NZ
-- Sterblue
+- domonda
+- Jack Dinker
+- DocIQ
+- nigelrmtaylor
+- Politics Rewired
+- Principia Mentis
 - HR-ON
-- Ian Stewart
-- Janakan Arulkumarasan
+- Luxor Labs
+- Dovetail
+- PostHog
+- Taiste
+- Axinom
+- Notably
+- Nathanael Beisiegel
+- William Baxter
+- SuperRare Labs
+- latch.bio
 
 ## Supporters
 
-- Daniel Einspanjer
+- Postlight
+- Philipp Litzenberger
 - Sam Levin
-- stlbucket
 - Matt Bretl
 - Chris Watland
+- Mark
+- svarmony
+- Simon Elliott
 - James Rascoe
-- Mark Lipscombe
-- Michel Pelletier
-- Frank
-- Mark Rapoza
-- innovation.rocks
-- cybere
-- Daniel Woelfel
-- Philipp Litzenberger
-- Bjørn Michelsen
-- CJ
-- Ben Botwin
-- Cameron Ellis
+- CJ Lazell
 - Mansoor Razzaq
-- Borut Jures
+- Jimmy Liu
+- Keith Layne
+- Olli Selamaa
+- Paul Melnikow
+- Alvin Ali Khaled
+- Dani Kenan
+- Stéphane Klein
+- Splitgraph
+- Kadi Kraman
+- Andrew Poland
+- OnThisSpot
+- Benjamin Berman
+- Zymego
+- ARK
+- Sen Palanisami
+- nick
+- CartoLab

--- a/packages/graphile-plugin/README.md
+++ b/packages/graphile-plugin/README.md
@@ -119,9 +119,13 @@ and development via sponsorship.
 And please give some love to our featured sponsors 🤩:
 
 <table><tr>
+<td align="center"><a href="https://surge.io/"><img src="https://graphile.org/images/sponsors/surge.png" width="90" height="90" alt="Surge" /><br />Surge</a> *</td>
+<td align="center"><a href="https://storyscript.com/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Story.ai" /><br />Story.ai</a> *</td>
 <td align="center"><a href="http://chads.website"><img src="https://graphile.org/images/sponsors/chadf.png" width="90" height="90" alt="Chad Furman" /><br />Chad Furman</a> *</td>
-<td align="center"><a href="https://storyscript.io/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Storyscript" /><br />Storyscript</a> *</td>
-<td align="center"><a href="https://postlight.com/?utm_source=graphile"><img src="https://graphile.org/images/sponsors/postlight.png" width="90" height="90" alt="Postlight" /><br />Postlight</a> *</td>
+<td align="center"><a href="https://www.the-guild.dev/"><img src="https://graphile.org/images/sponsors/theguild.png" width="90" height="90" alt="The Guild" /><br />The Guild</a> *</td>
+</tr><tr>
+<td align="center"><a href="https://www.fanatics.com/"><img src="https://graphile.org/images/sponsors/fanatics.png" width="90" height="90" alt="Fanatics" /><br />Fanatics</a> *</td>
+<td align="center"><a href="https://www.enzuzo.com/"><img src="https://graphile.org/images/sponsors/enzuzo.png" width="90" height="90" alt="Enzuzo" /><br />Enzuzo</a> *</td>
 </tr></table>
 
 <em>\* Sponsors the entire Graphile suite</em>

--- a/packages/graphile-plugin/SPONSORS.md
+++ b/packages/graphile-plugin/SPONSORS.md
@@ -6,49 +6,63 @@ Graphile ecosystem. Find out
 
 ## Featured
 
+- Surge
+- Story.ai
 - Chad Furman
-- Storyscript
-- Postlight
+- The Guild
+- Fanatics
+- Enzuzo
 
 ## Leaders
 
-- Joe Dennis
-- domonda
 - Robert Claypool
-- James Allain
-- Stagency
-- Jack Dinker
-- 8th Light
-- Nigel Taylor
-- DocIQ
-- Principia Mentis
+- Joe Dennis
 - Qwick
-- Partners in School Innovation
-- OpenLaw NZ
-- Sterblue
+- domonda
+- Jack Dinker
+- DocIQ
+- nigelrmtaylor
+- Politics Rewired
+- Principia Mentis
 - HR-ON
-- Ian Stewart
-- Janakan Arulkumarasan
+- Luxor Labs
+- Dovetail
+- PostHog
+- Taiste
+- Axinom
+- Notably
+- Nathanael Beisiegel
+- William Baxter
+- SuperRare Labs
+- latch.bio
 
 ## Supporters
 
-- Daniel Einspanjer
+- Postlight
+- Philipp Litzenberger
 - Sam Levin
-- stlbucket
 - Matt Bretl
 - Chris Watland
+- Mark
+- svarmony
+- Simon Elliott
 - James Rascoe
-- Mark Lipscombe
-- Michel Pelletier
-- Frank
-- Mark Rapoza
-- innovation.rocks
-- cybere
-- Daniel Woelfel
-- Philipp Litzenberger
-- Bjørn Michelsen
-- CJ
-- Ben Botwin
-- Cameron Ellis
+- CJ Lazell
 - Mansoor Razzaq
-- Borut Jures
+- Jimmy Liu
+- Keith Layne
+- Olli Selamaa
+- Paul Melnikow
+- Alvin Ali Khaled
+- Dani Kenan
+- Stéphane Klein
+- Splitgraph
+- Kadi Kraman
+- Andrew Poland
+- OnThisSpot
+- Benjamin Berman
+- Zymego
+- ARK
+- Sen Palanisami
+- nick
+- CartoLab

--- a/packages/lds/README.md
+++ b/packages/lds/README.md
@@ -22,9 +22,13 @@ and development via sponsorship.
 And please give some love to our featured sponsors 🤩:
 
 <table><tr>
+<td align="center"><a href="https://surge.io/"><img src="https://graphile.org/images/sponsors/surge.png" width="90" height="90" alt="Surge" /><br />Surge</a> *</td>
+<td align="center"><a href="https://storyscript.com/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Story.ai" /><br />Story.ai</a> *</td>
 <td align="center"><a href="http://chads.website"><img src="https://graphile.org/images/sponsors/chadf.png" width="90" height="90" alt="Chad Furman" /><br />Chad Furman</a> *</td>
-<td align="center"><a href="https://storyscript.io/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Storyscript" /><br />Storyscript</a> *</td>
-<td align="center"><a href="https://postlight.com/?utm_source=graphile"><img src="https://graphile.org/images/sponsors/postlight.png" width="90" height="90" alt="Postlight" /><br />Postlight</a> *</td>
+<td align="center"><a href="https://www.the-guild.dev/"><img src="https://graphile.org/images/sponsors/theguild.png" width="90" height="90" alt="The Guild" /><br />The Guild</a> *</td>
+</tr><tr>
+<td align="center"><a href="https://www.fanatics.com/"><img src="https://graphile.org/images/sponsors/fanatics.png" width="90" height="90" alt="Fanatics" /><br />Fanatics</a> *</td>
+<td align="center"><a href="https://www.enzuzo.com/"><img src="https://graphile.org/images/sponsors/enzuzo.png" width="90" height="90" alt="Enzuzo" /><br />Enzuzo</a> *</td>
 </tr></table>
 
 <em>\* Sponsors the entire Graphile suite</em>

--- a/packages/lds/SPONSORS.md
+++ b/packages/lds/SPONSORS.md
@@ -6,49 +6,63 @@ Graphile ecosystem. Find out
 
 ## Featured
 
+- Surge
+- Story.ai
 - Chad Furman
-- Storyscript
-- Postlight
+- The Guild
+- Fanatics
+- Enzuzo
 
 ## Leaders
 
-- Joe Dennis
-- domonda
 - Robert Claypool
-- James Allain
-- Stagency
-- Jack Dinker
-- 8th Light
-- Nigel Taylor
-- DocIQ
-- Principia Mentis
+- Joe Dennis
 - Qwick
-- Partners in School Innovation
-- OpenLaw NZ
-- Sterblue
+- domonda
+- Jack Dinker
+- DocIQ
+- nigelrmtaylor
+- Politics Rewired
+- Principia Mentis
 - HR-ON
-- Ian Stewart
-- Janakan Arulkumarasan
+- Luxor Labs
+- Dovetail
+- PostHog
+- Taiste
+- Axinom
+- Notably
+- Nathanael Beisiegel
+- William Baxter
+- SuperRare Labs
+- latch.bio
 
 ## Supporters
 
-- Daniel Einspanjer
+- Postlight
+- Philipp Litzenberger
 - Sam Levin
-- stlbucket
 - Matt Bretl
 - Chris Watland
+- Mark
+- svarmony
+- Simon Elliott
 - James Rascoe
-- Mark Lipscombe
-- Michel Pelletier
-- Frank
-- Mark Rapoza
-- innovation.rocks
-- cybere
-- Daniel Woelfel
-- Philipp Litzenberger
-- Bjørn Michelsen
-- CJ
-- Ben Botwin
-- Cameron Ellis
+- CJ Lazell
 - Mansoor Razzaq
-- Borut Jures
+- Jimmy Liu
+- Keith Layne
+- Olli Selamaa
+- Paul Melnikow
+- Alvin Ali Khaled
+- Dani Kenan
+- Stéphane Klein
+- Splitgraph
+- Kadi Kraman
+- Andrew Poland
+- OnThisSpot
+- Benjamin Berman
+- Zymego
+- ARK
+- Sen Palanisami
+- nick
+- CartoLab

--- a/packages/pg-introspection/README.md
+++ b/packages/pg-introspection/README.md
@@ -19,9 +19,13 @@ and development via sponsorship.
 And please give some love to our featured sponsors 🤩:
 
 <table><tr>
+<td align="center"><a href="https://surge.io/"><img src="https://graphile.org/images/sponsors/surge.png" width="90" height="90" alt="Surge" /><br />Surge</a> *</td>
+<td align="center"><a href="https://storyscript.com/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Story.ai" /><br />Story.ai</a> *</td>
 <td align="center"><a href="http://chads.website"><img src="https://graphile.org/images/sponsors/chadf.png" width="90" height="90" alt="Chad Furman" /><br />Chad Furman</a> *</td>
-<td align="center"><a href="https://storyscript.io/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Storyscript" /><br />Storyscript</a> *</td>
-<td align="center"><a href="https://postlight.com/?utm_source=graphile"><img src="https://graphile.org/images/sponsors/postlight.png" width="90" height="90" alt="Postlight" /><br />Postlight</a> *</td>
+<td align="center"><a href="https://www.the-guild.dev/"><img src="https://graphile.org/images/sponsors/theguild.png" width="90" height="90" alt="The Guild" /><br />The Guild</a> *</td>
+</tr><tr>
+<td align="center"><a href="https://www.fanatics.com/"><img src="https://graphile.org/images/sponsors/fanatics.png" width="90" height="90" alt="Fanatics" /><br />Fanatics</a> *</td>
+<td align="center"><a href="https://www.enzuzo.com/"><img src="https://graphile.org/images/sponsors/enzuzo.png" width="90" height="90" alt="Enzuzo" /><br />Enzuzo</a> *</td>
 </tr></table>
 
 <em>\* Sponsors the entire Graphile suite</em>

--- a/packages/pg-introspection/SPONSORS.md
+++ b/packages/pg-introspection/SPONSORS.md
@@ -6,49 +6,63 @@ Graphile ecosystem. Find out
 
 ## Featured
 
+- Surge
+- Story.ai
 - Chad Furman
-- Storyscript
-- Postlight
+- The Guild
+- Fanatics
+- Enzuzo
 
 ## Leaders
 
-- Joe Dennis
-- domonda
 - Robert Claypool
-- James Allain
-- Stagency
-- Jack Dinker
-- 8th Light
-- Nigel Taylor
-- DocIQ
-- Principia Mentis
+- Joe Dennis
 - Qwick
-- Partners in School Innovation
-- OpenLaw NZ
-- Sterblue
+- domonda
+- Jack Dinker
+- DocIQ
+- nigelrmtaylor
+- Politics Rewired
+- Principia Mentis
 - HR-ON
-- Ian Stewart
-- Janakan Arulkumarasan
+- Luxor Labs
+- Dovetail
+- PostHog
+- Taiste
+- Axinom
+- Notably
+- Nathanael Beisiegel
+- William Baxter
+- SuperRare Labs
+- latch.bio
 
 ## Supporters
 
-- Daniel Einspanjer
+- Postlight
+- Philipp Litzenberger
 - Sam Levin
-- stlbucket
 - Matt Bretl
 - Chris Watland
+- Mark
+- svarmony
+- Simon Elliott
 - James Rascoe
-- Mark Lipscombe
-- Michel Pelletier
-- Frank
-- Mark Rapoza
-- innovation.rocks
-- cybere
-- Daniel Woelfel
-- Philipp Litzenberger
-- Bjørn Michelsen
-- CJ
-- Ben Botwin
-- Cameron Ellis
+- CJ Lazell
 - Mansoor Razzaq
-- Borut Jures
+- Jimmy Liu
+- Keith Layne
+- Olli Selamaa
+- Paul Melnikow
+- Alvin Ali Khaled
+- Dani Kenan
+- Stéphane Klein
+- Splitgraph
+- Kadi Kraman
+- Andrew Poland
+- OnThisSpot
+- Benjamin Berman
+- Zymego
+- ARK
+- Sen Palanisami
+- nick
+- CartoLab

--- a/packages/pg-sql2/README.md
+++ b/packages/pg-sql2/README.md
@@ -19,9 +19,13 @@ and development via sponsorship.
 And please give some love to our featured sponsors 🤩:
 
 <table><tr>
+<td align="center"><a href="https://surge.io/"><img src="https://graphile.org/images/sponsors/surge.png" width="90" height="90" alt="Surge" /><br />Surge</a> *</td>
+<td align="center"><a href="https://storyscript.com/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Story.ai" /><br />Story.ai</a> *</td>
 <td align="center"><a href="http://chads.website"><img src="https://graphile.org/images/sponsors/chadf.png" width="90" height="90" alt="Chad Furman" /><br />Chad Furman</a> *</td>
-<td align="center"><a href="https://storyscript.io/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Storyscript" /><br />Storyscript</a> *</td>
-<td align="center"><a href="https://postlight.com/?utm_source=graphile"><img src="https://graphile.org/images/sponsors/postlight.png" width="90" height="90" alt="Postlight" /><br />Postlight</a> *</td>
+<td align="center"><a href="https://www.the-guild.dev/"><img src="https://graphile.org/images/sponsors/theguild.png" width="90" height="90" alt="The Guild" /><br />The Guild</a> *</td>
+</tr><tr>
+<td align="center"><a href="https://www.fanatics.com/"><img src="https://graphile.org/images/sponsors/fanatics.png" width="90" height="90" alt="Fanatics" /><br />Fanatics</a> *</td>
+<td align="center"><a href="https://www.enzuzo.com/"><img src="https://graphile.org/images/sponsors/enzuzo.png" width="90" height="90" alt="Enzuzo" /><br />Enzuzo</a> *</td>
 </tr></table>
 
 <em>\* Sponsors the entire Graphile suite</em>

--- a/packages/pg-sql2/SPONSORS.md
+++ b/packages/pg-sql2/SPONSORS.md
@@ -6,49 +6,63 @@ Graphile ecosystem. Find out
 
 ## Featured
 
+- Surge
+- Story.ai
 - Chad Furman
-- Storyscript
-- Postlight
+- The Guild
+- Fanatics
+- Enzuzo
 
 ## Leaders
 
-- Joe Dennis
-- domonda
 - Robert Claypool
-- James Allain
-- Stagency
-- Jack Dinker
-- 8th Light
-- Nigel Taylor
-- DocIQ
-- Principia Mentis
+- Joe Dennis
 - Qwick
-- Partners in School Innovation
-- OpenLaw NZ
-- Sterblue
+- domonda
+- Jack Dinker
+- DocIQ
+- nigelrmtaylor
+- Politics Rewired
+- Principia Mentis
 - HR-ON
-- Ian Stewart
-- Janakan Arulkumarasan
+- Luxor Labs
+- Dovetail
+- PostHog
+- Taiste
+- Axinom
+- Notably
+- Nathanael Beisiegel
+- William Baxter
+- SuperRare Labs
+- latch.bio
 
 ## Supporters
 
-- Daniel Einspanjer
+- Postlight
+- Philipp Litzenberger
 - Sam Levin
-- stlbucket
 - Matt Bretl
 - Chris Watland
+- Mark
+- svarmony
+- Simon Elliott
 - James Rascoe
-- Mark Lipscombe
-- Michel Pelletier
-- Frank
-- Mark Rapoza
-- innovation.rocks
-- cybere
-- Daniel Woelfel
-- Philipp Litzenberger
-- Bjørn Michelsen
-- CJ
-- Ben Botwin
-- Cameron Ellis
+- CJ Lazell
 - Mansoor Razzaq
-- Borut Jures
+- Jimmy Liu
+- Keith Layne
+- Olli Selamaa
+- Paul Melnikow
+- Alvin Ali Khaled
+- Dani Kenan
+- Stéphane Klein
+- Splitgraph
+- Kadi Kraman
+- Andrew Poland
+- OnThisSpot
+- Benjamin Berman
+- Zymego
+- ARK
+- Sen Palanisami
+- nick
+- CartoLab


### PR DESCRIPTION
## Description
@benjie Is this right? it has taken out the Project sponsor to PostGraphile I think (Politics Rewired)


Sponsorship update for Spring 2022. Thank you to all our sponsors, past and present, your donations help us to keep working on free and open source software 💖

## Checklist
NA