### PR TITLE
Skip unknown fields

### DIFF
--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -827,15 +827,13 @@ export class OperationPlan {
         // All grouped fields are equivalent, as mandated by GraphQL validation rules. Thus we can take the first one.
         const field = fieldNodes[0];
         const fieldName = field.name.value;
+        const objectField = objectTypeFields[fieldName];
 
         const locationDetails: LocationDetails = {
           parentTypeName: objectType.name,
           fieldName,
           node: fieldNodes,
         };
-
-        // This is presumed to exist because the operation passed validation.
-        const objectField = objectTypeFields[fieldName];
 
         if (fieldName.startsWith("__")) {
           if (fieldName === "__typename") {
@@ -867,7 +865,14 @@ export class OperationPlan {
           }
           continue;
         }
-        const fieldType = objectTypeFields[fieldName].type;
+
+        if (!objectField) {
+          // Field does not exist; this should have been caught by validation
+          // but the spec says to just skip it.
+          continue;
+        }
+
+        const fieldType = objectField.type;
         const rawPlanResolver = objectField.extensions?.graphile?.plan;
         const namedReturnType = getNamedType(fieldType);
 


### PR DESCRIPTION
This is just to increase spec compliance, technically it should never be hit if the operation validates against the schema.