### PR TITLE
Ruru: hide the explain output in result pane by default

### DIFF
--- a/grafast/ruru/src/hooks/useStorage.ts
+++ b/grafast/ruru/src/hooks/useStorage.ts
@@ -9,6 +9,7 @@ export interface StoredKeys {
   explainAtBottom: "true" | "";
   explainSize: string;
   query: string;
+  verbose: "true" | "";
 }
 
 const KEYS: { [key in keyof StoredKeys]: string } = {
@@ -20,6 +21,7 @@ const KEYS: { [key in keyof StoredKeys]: string } = {
   explainAtBottom: "Ruru:explainAtBottom",
   explorerIsOpen: "graphiql:explorerIsOpen",
   query: "graphiql:query",
+  verbose: "Ruru:verbose",
 };
 
 const up = (v: number) => v + 1;

--- a/grafast/ruru/src/ruru.tsx
+++ b/grafast/ruru/src/ruru.tsx
@@ -37,6 +37,7 @@ const nocheck = <span style={checkCss}></span>;
 export const Ruru: FC<RuruProps> = (props) => {
   const storage = useStorage();
   const explain = storage.get("explain") === "true";
+  const verbose = storage.get("verbose") === "true";
   const setExplain = useCallback(
     (newExplain: boolean) => {
       storage.set("explain", newExplain ? "true" : "");
@@ -45,6 +46,7 @@ export const Ruru: FC<RuruProps> = (props) => {
   );
   const { fetcher, explainResults, streamEndpoint } = useFetcher(props, {
     explain,
+    verbose,
   });
   const [error, setError] = useState<Error | null>(null);
   const explainHelpers = useExplain(storage);
@@ -172,6 +174,15 @@ export const RuruInner: FC<{
                 <span>
                   {storage.get("explain") === "true" ? check : nocheck}
                   Explain (if supported)
+                </span>
+              </ToolbarMenu.Item>
+              <ToolbarMenu.Item
+                title="Don't hide explain from results"
+                onSelect={() => storage.toggle("verbose")}
+              >
+                <span>
+                  {storage.get("verbose") === "true" ? check : nocheck}
+                  Verbose
                 </span>
               </ToolbarMenu.Item>
               <ToolbarMenu.Item


### PR DESCRIPTION
Previously we'd see the explain output in the output; really distracting/confusing for the user:

![image](https://user-images.githubusercontent.com/129910/194900119-c6078605-76ee-4834-aaf7-64a21d286541.png)

This PR hides that unless you turn on verbose mode:

![image](https://user-images.githubusercontent.com/129910/194900376-462719cb-12a4-4793-bde4-d4b356b3f95d.png)

Much nicer.

(The plan itself is still viewable in the plan plugin.)
