### PR TITLE
Allow sql.indent to be used as a template literal

### DIFF
--- a/utils/pg-sql2/src/index.ts
+++ b/utils/pg-sql2/src/index.ts
@@ -773,7 +773,19 @@ export function join(
   return currentItems;
 }
 
-export function indent(fragment: SQL): SQL {
+export function indent(fragment: SQL): SQL;
+export function indent(
+  strings: TemplateStringsArray,
+  ...values: Array<SQL>
+): SQL;
+export function indent(
+  fragmentOrStrings: SQL | TemplateStringsArray,
+  ...values: Array<SQL>
+): SQL {
+  const fragment =
+    "raw" in fragmentOrStrings
+      ? sql(fragmentOrStrings, ...values)
+      : fragmentOrStrings;
   return isDev ? makeIndentNode(fragment) : fragment;
 }
 


### PR DESCRIPTION
Extracted from #100 to make review easier