### PR TITLE
Replace `{}` with `Object.create(null)` in various places

### DIFF
--- a/grafast/dataplan-pg/src/steps/pgUnionAll.ts
+++ b/grafast/dataplan-pg/src/steps/pgUnionAll.ts
@@ -249,7 +249,7 @@ export class PgUnionAllSingleStep
         `No PK found for ${objectType.name}; this should have been caught earlier?!`,
       );
     }
-    const spec = {};
+    const spec = Object.create(null);
     const $parsed = jsonParse(access(this, [$$data, this.pkKey]));
     for (let i = 0, l = pk.columns.length; i < l; i++) {
       const col = pk.columns[i];

--- a/grafast/grafast/src/engine/OutputPlan.ts
+++ b/grafast/grafast/src/engine/OutputPlan.ts
@@ -1127,7 +1127,7 @@ const introspect = (
 
     kind: Kind.DOCUMENT,
   };
-  const variableValues: Record<string, any> = {};
+  const variableValues: Record<string, any> = Object.create(null);
   for (const variableName of variableNames) {
     variableValues[variableName] = root.variables[variableName];
   }

--- a/grafast/grafast/src/makeGrafastSchema.ts
+++ b/grafast/grafast/src/makeGrafastSchema.ts
@@ -169,7 +169,7 @@ export function makeGrafastSchema(details: {
           const graphileExtensions: GraphQLFieldExtensions<
             any,
             any
-          >["graphile"] = {};
+          >["graphile"] = Object.create(null);
           (field.extensions as any).graphile = graphileExtensions;
           if (fieldSpec.resolve) {
             field.resolve = fieldSpec.resolve;
@@ -178,10 +178,10 @@ export function makeGrafastSchema(details: {
             field.subscribe = fieldSpec.subscribe;
           }
           if (fieldSpec.plan) {
-            graphileExtensions.plan = fieldSpec.plan;
+            graphileExtensions!.plan = fieldSpec.plan;
           }
           if (fieldSpec.subscribePlan) {
-            graphileExtensions.subscribePlan = fieldSpec.subscribePlan;
+            graphileExtensions!.subscribePlan = fieldSpec.subscribePlan;
           }
 
           if (typeof fieldSpec.args === "object" && fieldSpec.args != null) {

--- a/grafast/grafast/src/mermaid.ts
+++ b/grafast/grafast/src/mermaid.ts
@@ -178,7 +178,7 @@ export function printPlanGraph(
 
   graph.push("");
   graph.push("    %% plan dependencies");
-  const chainByDep: { [depNode: string]: string } = {};
+  const chainByDep: { [depNode: string]: string } = Object.create(null);
   operationPlan.processSteps(
     "printingPlanDeps",
     0,

--- a/grafast/grafast/src/opPlan-input.ts
+++ b/grafast/grafast/src/opPlan-input.ts
@@ -42,7 +42,7 @@ export function withFieldArgsForArguments<
     operationPlan.loc.push(`withFieldArgsForArguments(${field.name})`);
   const fields: {
     [key: string]: GraphQLArgument;
-  } = {};
+  } = Object.create(null);
   const args = field.args;
   for (const arg of args) {
     fields[arg.name] = arg;
@@ -534,7 +534,7 @@ function withFieldArgsForArgOrField<
 const defaultInputObjectTypeInputPlanResolver: InputObjectTypeInputPlanResolver =
   (input, info) => {
     const fields = info.type.getFields();
-    const obj: { [key: string]: ExecutableStep } = {};
+    const obj: { [key: string]: ExecutableStep } = Object.create(null);
     for (const fieldName in fields) {
       obj[fieldName] = input.get(fieldName);
     }

--- a/graphile-build/graphile-build-pg/src/examples/NO_DATA_GATHERING.ts
+++ b/graphile-build/graphile-build-pg/src/examples/NO_DATA_GATHERING.ts
@@ -533,7 +533,7 @@ async function main() {
   const contextValue = {
     withPgClient,
   };
-  const variableValues = {};
+  const variableValues = Object.create(null);
 
   // Run our query
   const result = await graphql({

--- a/graphile-build/graphile-build-pg/src/examples/benjies-test-script.ts
+++ b/graphile-build/graphile-build-pg/src/examples/benjies-test-script.ts
@@ -133,7 +133,7 @@ pool.on("error", (e) => {
   };
 
   // Our operation requires no variables
-  const variableValues = {};
+  const variableValues = Object.create(null);
 
   // Run our query on our initial schema
   const result = await graphql({

--- a/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
@@ -334,7 +334,7 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
             );
           }
 
-          const columns: PgTypeColumns = {};
+          const columns: PgTypeColumns = Object.create(null);
           const allAttributes =
             await info.helpers.pgIntrospection.getAttributesForClass(
               databaseName,

--- a/graphile-build/graphile-build-pg/src/plugins/PgJWTPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgJWTPlugin.ts
@@ -55,9 +55,9 @@ export const PgJWTPlugin: GraphileConfig.Plugin = {
           info.options.pgJwtType?.[0] === pgType.getNamespace()!.nspname
         ) {
           // It's a JWT type!
-          pgCodec.extensions ||= {};
-          pgCodec.extensions.tags ||= {};
-          pgCodec.extensions.tags.behavior = ["-table", "jwt"];
+          pgCodec.extensions ||= Object.create(null);
+          pgCodec.extensions!.tags ||= Object.create(null);
+          pgCodec.extensions!.tags!.behavior = ["-table", "jwt"];
         }
       },
     },

--- a/graphile-build/graphile-build-pg/src/plugins/PgProceduresPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgProceduresPlugin.ts
@@ -219,7 +219,7 @@ export const PgProceduresPlugin: GraphileConfig.Plugin = {
             // return type of this function.
 
             const numberOfArguments = allArgTypes.length ?? 0;
-            const columns: PgTypeColumns = {};
+            const columns: PgTypeColumns = Object.create(null);
             for (let i = 0, l = numberOfArguments; i < l; i++) {
               const argType = allArgTypes[i];
               const trueArgName = pgProc.proargnames?.[i];

--- a/graphile-build/graphile-build-pg/src/plugins/PgRemoveExtensionResourcesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgRemoveExtensionResourcesPlugin.ts
@@ -26,7 +26,7 @@ export const PgRemoveExtensionResourcesPlugin: GraphileConfig.Plugin = {
     hooks: {
       pgIntrospection_introspection(info, event) {
         const { introspection } = event;
-        const oidByCatalog = {};
+        const oidByCatalog = Object.create(null);
         for (const oid in introspection.catalog_by_oid) {
           oidByCatalog[introspection.catalog_by_oid[oid]] = oid;
         }

--- a/graphile-build/graphile-build-pg/src/plugins/PgRowByUniquePlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgRowByUniquePlugin.ts
@@ -141,7 +141,7 @@ return function (source) {
                   : EXPORTABLE(
                       (detailsByColumnName, source) =>
                         function plan(_$root: any, args: FieldArgs) {
-                          const spec = {};
+                          const spec = Object.create(null);
                           for (const columnName in detailsByColumnName) {
                             spec[columnName] = args.get(
                               detailsByColumnName[columnName].graphqlName,

--- a/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
@@ -338,7 +338,8 @@ export const PgTablesPlugin: GraphileConfig.Plugin = {
           return source;
         }
         source = (async () => {
-          const relations: GraphileConfig.PgTablesPluginSourceRelations = {};
+          const relations: GraphileConfig.PgTablesPluginSourceRelations =
+            Object.create(null);
           const { pgClass, databaseName } =
             info.state.detailsBySourceBuilder.get(sourceBuilder)!;
           await info.process("pgTables_PgSourceBuilder_relations", {

--- a/graphile-build/graphile-build/src/examples/README-1.ts
+++ b/graphile-build/graphile-build/src/examples/README-1.ts
@@ -96,7 +96,7 @@ const MyRandomFieldPlugin: GraphileConfig.Plugin = {
   ]);
 
   // This'd normally be the "gather" phase, but we don't need one
-  const input: GraphileBuild.BuildInput = {};
+  const input: GraphileBuild.BuildInput = Object.create(null);
 
   // Build the schema:
   const schema = buildSchema(config, input);

--- a/graphile-build/graphile-build/src/index.ts
+++ b/graphile-build/graphile-build/src/index.ts
@@ -123,9 +123,9 @@ const gatherBase = (
   const resolvedPreset = resolvePresets([preset]);
   const options = resolvedPreset.gather || {};
   const plugins = resolvedPreset.plugins;
-  const globalState: { [key: string]: any } = {};
-  const gatherState: { [key: string]: any } = {};
-  const helpers: { [key: string]: any } = {}; // GatherHelpers
+  const globalState: { [key: string]: any } = Object.create(null);
+  const gatherState: { [key: string]: any } = Object.create(null);
+  const helpers: { [key: string]: any } = Object.create(null); // GatherHelpers
 
   const hooks = new AsyncHooks<GraphileConfig.GatherHooks>();
 
@@ -167,7 +167,7 @@ const gatherBase = (
       };
       pluginContext.set(plugin, context);
       if (spec.namespace != null) {
-        helpers[spec.namespace] = {};
+        helpers[spec.namespace] = Object.create(null);
         if (spec.helpers != null) {
           const specHelpers = spec.helpers;
           for (const helperName of Object.keys(specHelpers)) {
@@ -196,7 +196,7 @@ const gatherBase = (
   }
 
   async function run() {
-    const output: Partial<GraphileBuild.BuildInput> = {};
+    const output: Partial<GraphileBuild.BuildInput> = Object.create(null);
     if (gatherPlugins) {
       // Reset state
       for (const plugin of gatherPlugins) {

--- a/graphile-build/graphile-build/src/makeNewBuild.ts
+++ b/graphile-build/graphile-build/src/makeNewBuild.ts
@@ -74,7 +74,7 @@ export default function makeNewBuild(
       origin: string | null | undefined;
       Step?: { new (...args: any[]): ExecutableStep<any> } | null;
     };
-  } = {};
+  } = Object.create(null);
 
   const scopeByType = new Map<GraphQLNamedType, GraphileBuild.SomeScope>();
 

--- a/graphile-build/graphile-build/src/plugins/ConnectionPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/ConnectionPlugin.ts
@@ -45,7 +45,11 @@ export const ConnectionPlugin: GraphileConfig.Plugin = {
             registerCursorConnection(
               options: GraphileBuild.RegisterCursorConnectionOptions,
             ) {
-              const { typeName, scope = {}, nonNullNode = false } = options;
+              const {
+                typeName,
+                scope = Object.create(null),
+                nonNullNode = false,
+              } = options;
               if (
                 (options.connectionTypeName || options.edgeTypeName) &&
                 !(options.connectionTypeName && options.edgeTypeName)

--- a/graphile-build/graphile-utils/src/gql.ts
+++ b/graphile-build/graphile-utils/src/gql.ts
@@ -16,7 +16,7 @@ export function gql(
   ...interpolatedValues: Array<string | DocumentNode>
 ): DocumentNode {
   const gqlStrings = [];
-  const placeholders = {};
+  const placeholders = Object.create(null);
   const additionalDefinitions: Array<DefinitionNode> = [];
   for (let idx = 0, length = strings.length; idx < length; idx++) {
     gqlStrings.push(strings[idx]);

--- a/postgraphile/postgraphile/src/plugins/PgV4NoIgnoreIndexes.ts
+++ b/postgraphile/postgraphile/src/plugins/PgV4NoIgnoreIndexes.ts
@@ -67,12 +67,12 @@ export const PgV4NoIgnoreIndexesPlugin: GraphileConfig.Plugin = {
           });
         if (!isIndexed) {
           if (!column.extensions) {
-            column.extensions = {};
+            column.extensions = Object.create(null);
           }
-          if (!column.extensions.tags) {
-            column.extensions.tags = Object.create(null);
+          if (!column.extensions!.tags) {
+            column.extensions!.tags = Object.create(null);
           }
-          addBehaviorToTags(column.extensions.tags!, "-filterBy -orderBy");
+          addBehaviorToTags(column.extensions!.tags!, "-filterBy -orderBy");
         }
       },
     },

--- a/utils/graphile-config/src/hooks.ts
+++ b/utils/graphile-config/src/hooks.ts
@@ -11,7 +11,7 @@ export class AsyncHooks<THooks extends HookObject<THooks>> {
     [key in keyof THooks]?: Array<
       THooks[keyof THooks] extends PluginHook<infer U> ? U : never
     >;
-  } = {};
+  } = Object.create(null);
 
   hook<THookName extends keyof THooks>(
     event: THookName,

--- a/utils/pg-introspection/src/augmentIntrospection.ts
+++ b/utils/pg-introspection/src/augmentIntrospection.ts
@@ -60,7 +60,7 @@ export function augmentIntrospection(
   const introspectionResults = JSON.parse(introspectionResultsString);
   const introspection = introspectionResults as Introspection;
 
-  const oidByCatalog: { [catalog: string]: string } = {};
+  const oidByCatalog: { [catalog: string]: string } = Object.create(null);
   for (const [oid, catalog] of Object.entries(introspection.catalog_by_oid)) {
     oidByCatalog[catalog] = oid;
   }

--- a/utils/pg-sql2/src/index.ts
+++ b/utils/pg-sql2/src/index.ts
@@ -360,7 +360,7 @@ export function compile(
    */
   const descCounter: {
     [description: string]: number;
-  } = {};
+  } = Object.create(null);
 
   /**
    * Makes a friendly name to use in the query for the given SymbolAndName.


### PR DESCRIPTION
Really must stop being lazy. Generally when we're using `{}` as a map (rather than a simple object that we assign predefined keys to) we should use `Object.create(null)` so that special keys such as `__proto__`, `constructor`, etc do not cause any issues. I've not changed `{}` where it's being used for an options object or similar - since those are trusted objects there's no need for protection.