### PR TITLE
Fix/improve docs

### DIFF
--- a/grafast/dataplan-pg/serve-example-schema.js
+++ b/grafast/dataplan-pg/serve-example-schema.js
@@ -1,5 +1,5 @@
 const { makeExampleSchema } = require("./dist/examples/exampleSchema");
-const { grafserv } = require("grafserv");
+const { grafserv } = require("grafserv/node");
 const { createServer } = require("node:http");
 const { createWithPgClient } = require("./dist/adaptors/node-postgres");
 
@@ -7,10 +7,10 @@ const schema = makeExampleSchema();
 const withPgClient = createWithPgClient({
   connectionString: process.env.TEST_DATABASE_URL || "graphile_grafast",
 });
-const instance = grafserv(
-  { grafast: { context: { withPgClient }, explain: true } },
-  { schema },
-);
-const server = createServer(instance.handler);
+const serv = grafserv({
+  preset: { grafast: { context: { withPgClient }, explain: true } },
+  schema,
+});
+const server = createServer(serv.createHandler());
 server.listen(5555);
 console.log("Listening on http://localhost:5555/");

--- a/grafast/grafserv/README.md
+++ b/grafast/grafserv/README.md
@@ -50,7 +50,7 @@ function from the relevant entrypoint for your server of choice and then create
 an instance:
 
 ```js
-const instance = grafserv({ schema, preset });
+const serv = grafserv({ schema, preset });
 ```
 
 `grafserv` is passed the GraphQL schema to use (if it's available, otherwise
@@ -60,9 +60,9 @@ preset - i.e. your configuration.
 Calling `grafserv` will return an instance; this instance will have a number of
 helpers on it, including helpers specific to integrating it with your framework
 of choice. For servers that operate on a middleware basis this is typically
-`instance.addTo(app)` (which allows registering multiple route handlers), though
-different servers may have different APIs, such as `instance.createHandler()`
-for Node and `instance.createGraphQLHandler()` for Lambda and Next.js.
+`serv.addTo(app)` (which allows registering multiple route handlers), though
+different servers may have different APIs, such as `serv.createHandler()` for
+Node and `serv.createGraphQLHandler()` for Lambda and Next.js.
 
 Note: There is little value in Grafserv reimplementing every non-GraphQL concern
 your server may have, so instead it leans on the ecosystem of your chosen server
@@ -73,36 +73,36 @@ for Express, [`koa-compress`](https://www.npmjs.com/package/koa-compress) for
 Koa, or [`@fastify/compress`](https://www.npmjs.com/package/@fastify/compress)
 for Fastify.
 
-### instance.release()
+### serv.release()
 
 Releases any resources created by the instance; no further requests should be
 handled (though currently active requests will be allowed to complete).
 
 // TODO: consider terminating subscriptions or other long-lived things.
 
-### instance.onRelease(cb)
+### serv.onRelease(cb)
 
 Adds `cb` to the list of callbacks to be called when the server is released;
 useful for releasing resources you created only for the server. Callbacks will
 be called in reverse order that they were added.
 
-### instance.setSchema(newSchema)
+### serv.setSchema(newSchema)
 
 Replaces the schema to use for future requests (currently active requests are
 unaffected) - this is primarily used for "watch" mode.
 
-### instance.setPreset(newPreset)
+### serv.setPreset(newPreset)
 
 Replaces the config to use for future requests (currently active requests are
 unaffected) - this is primarily used for "watch" mode. Note that certain
 configuration changes might not be reflected by certain servers until a restart.
 
-### instance.getSchema()
+### serv.getSchema()
 
 Returns either the GraphQL schema that is currently in use, or a promise to the
 same.
 
-### instance.getPreset()
+### serv.getPreset()
 
 Returns the resolved `graphile-config` preset that is currently in use.
 
@@ -117,10 +117,10 @@ import preset from "./graphile.config.mjs";
 import schema from "./schema.mjs";
 
 // Create a Grafserv instance
-const instance = grafserv({ schema, preset });
+const serv = grafserv({ schema, preset });
 
 // Mount the request handler into a new HTTP server
-const server = createServer(instance.createHandler());
+const server = createServer(serv.createHandler());
 
 // Start the Node server
 server.listen(preset.server.port ?? 5678);
@@ -139,10 +139,10 @@ const app = express();
 // (Add any Express middleware you want here.)
 
 // Create a Grafserv instance
-const instance = grafserv({ schema, preset });
+const serv = grafserv({ schema, preset });
 
 // Add the Grafserv instance's route handlers to the Express app
-instance.addTo(app);
+serv.addTo(app);
 
 // Start the Express server
 app.listen(preset.server.port ?? 5678);
@@ -161,10 +161,10 @@ const app = new Koa();
 // (Add any Koa middleware you want here.)
 
 // Create a Grafserv instance
-const instance = grafserv({ schema, preset });
+const serv = grafserv({ schema, preset });
 
 // Add the Grafserv instance's route handlers to the Koa app
-instance.addTo(app);
+serv.addTo(app);
 
 // Start the Koa server
 app.listen(preset.server.port ?? 5678);
@@ -185,10 +185,10 @@ const app = Fastify({
 // (Add any Fastify middleware you want here.)
 
 // Create a Grafserv instance
-const instance = grafserv({ schema, preset });
+const serv = grafserv({ schema, preset });
 
 // Add the Grafserv instance's route handlers to the Fastify app
-instance.addTo(app);
+serv.addTo(app);
 
 // Start the Fastify server
 app.listen({ port: preset.server.port ?? 5678 }, (err, address) => {
@@ -212,24 +212,24 @@ import preset from "./graphile.config.mjs";
 import schema from "./schema.mjs";
 
 // Create a shared Grafserv instance
-export const instance = grafserv({ schema, preset });
+export const serv = grafserv({ schema, preset });
 ```
 
 ```js
 // pages/api/graphql.mjs
-import { instance } from "../../utils/grafserv.mjs";
+import { serv } from "../../utils/grafserv.mjs";
 
 // Create and export the `/graphql` route handler
-const handler = instance.createGraphQLHandler();
+const handler = serv.createGraphQLHandler();
 export default handler;
 ```
 
 ```js
 // pages/api/ruru.mjs
-import { instance } from "../../utils/grafserv.mjs";
+import { serv } from "../../utils/grafserv.mjs";
 
 // Create and export the `/ruru` route handler
-const handler = instance.createRuruHandler();
+const handler = serv.createRuruHandler();
 export default handler;
 ```
 
@@ -241,8 +241,8 @@ import preset from "./graphile.config.mjs";
 import schema from "./schema.mjs";
 
 // Create a Grafserv instance
-const instance = grafserv({ schema, preset });
+const serv = grafserv({ schema, preset });
 
 // Export a lambda handler for GraphQL
-export const handler = instance.createGraphQLHandler();
+export const handler = serv.createGraphQLHandler();
 ```

--- a/grafast/grafserv/examples/example-express.mjs
+++ b/grafast/grafserv/examples/example-express.mjs
@@ -12,10 +12,10 @@ app.use((req, _res, next) => {
 });
 
 // Create a Grafserv instance
-const instance = grafserv({ schema, preset });
+const serv = grafserv({ schema, preset });
 
 // Add the Grafserv instance's route handlers to the Express app
-instance.addTo(app);
+serv.addTo(app);
 
 // Start the Express server
 app.listen(preset.server.port ?? 5678);

--- a/grafast/grafserv/examples/example-fastify.mjs
+++ b/grafast/grafserv/examples/example-fastify.mjs
@@ -13,10 +13,10 @@ app.addHook("onRequest", async (request, _reply) => {
 });
 
 // Create a Grafserv instance
-const instance = grafserv({ schema, preset });
+const serv = grafserv({ schema, preset });
 
 // Add the Grafserv instance's route handlers to the Fastify app
-instance.addTo(app);
+serv.addTo(app);
 
 // Start the Fastify server
 app.listen({ port: preset.server.port ?? 5678 }, (err, address) => {

--- a/grafast/grafserv/examples/example-koa.extra.mjs
+++ b/grafast/grafserv/examples/example-koa.extra.mjs
@@ -11,10 +11,10 @@ app.use(bodyParser());
 // (Add any Koa middleware you want here.)
 
 // Create a Grafserv instance
-const instance = grafserv({ schema, preset });
+const serv = grafserv({ schema, preset });
 
 // Add the Grafserv instance's route handlers to the Koa app
-instance.addTo(app);
+serv.addTo(app);
 
 // Start the Koa server
 app.listen(preset.server.port ?? 5678);

--- a/grafast/grafserv/examples/example-koa.mjs
+++ b/grafast/grafserv/examples/example-koa.mjs
@@ -12,10 +12,10 @@ app.use(async (ctx, next) => {
 });
 
 // Create a Grafserv instance
-const instance = grafserv({ schema, preset });
+const serv = grafserv({ schema, preset });
 
 // Add the Grafserv instance's route handlers to the Koa app
-instance.addTo(app);
+serv.addTo(app);
 
 // Start the Koa server
 app.listen(preset.server.port ?? 5678);

--- a/grafast/grafserv/examples/example-node.mjs
+++ b/grafast/grafserv/examples/example-node.mjs
@@ -4,10 +4,10 @@ import preset from "./graphile.config.mjs";
 import schema from "./schema.mjs";
 
 // Create a Grafserv instance
-const instance = grafserv({ schema, preset });
+const serv = grafserv({ schema, preset });
 
 // Mount the request handler into a new HTTP server
-const server = createServer(instance.createHandler());
+const server = createServer(serv.createHandler());
 
 // Start the Node server
 server.listen(preset.server.port ?? 5678);

--- a/grafast/website/grafserv/index.md
+++ b/grafast/website/grafserv/index.md
@@ -7,6 +7,10 @@ sidebar_position: 1
 Grafserv - an incredibly fast GraphQL server for Node.js powered by
 [Grafast](/grafast/).
 
+<!-- FIXME: actual documentation please! -->
+
+See: https://www.npmjs.com/package/grafserv/v/0.0.1-0.7
+
 <!--
 
 ### Mounting PostGraphile middleware under a subpath

--- a/postgraphile/postgraphile/src/cli.ts
+++ b/postgraphile/postgraphile/src/cli.ts
@@ -187,9 +187,9 @@ export async function run(args: ArgsFromOptions<typeof options>) {
     process.exit(2);
   }
 
-  const instance = postgraphile(config);
+  const pgl = postgraphile(config);
 
-  const serv = instance.createServ(grafserv);
+  const serv = pgl.createServ(grafserv);
 
   const server = createServer(serv.createHandler());
   server.once("listening", () => {

--- a/postgraphile/postgraphile/src/index.ts
+++ b/postgraphile/postgraphile/src/index.ts
@@ -21,15 +21,16 @@ export function postgraphile(preset: GraphileConfig.Preset): {
   ): TGrafserv;
   getServerParams(): Promise<ServerParams>;
   getSchema(): Promise<GraphQLSchema>;
+  getResolvedPreset(): GraphileConfig.ResolvedPreset;
   release(): Promise<void>;
 } {
-  const config = resolvePresets([preset]);
+  const resolvedPreset = resolvePresets([preset]);
   let serverParams:
     | PromiseLike<ServerParams>
     | Deferred<ServerParams>
     | ServerParams;
   let stopWatchingPromise: Promise<() => void> | null = null;
-  if (config.server?.watch) {
+  if (resolvedPreset.server?.watch) {
     serverParams = defer<ServerParams>();
     stopWatchingPromise = watchSchema(preset, (error, newParams) => {
       if (error || !newParams) {
@@ -94,6 +95,9 @@ export function postgraphile(preset: GraphileConfig.Preset): {
     async getSchema() {
       assertAlive();
       return (await serverParams).schema;
+    },
+    getResolvedPreset() {
+      return resolvedPreset;
     },
     async release() {
       assertAlive();

--- a/postgraphile/website/postgraphile/migrating-from-v4/index.md
+++ b/postgraphile/website/postgraphile/migrating-from-v4/index.md
@@ -53,13 +53,13 @@ initial preset) to get a completed config:
 import "graphile-config";
 
 import { makePgSources } from "postgraphile";
-import postgraphilePresetAmber from "postgraphile/presets/amber";
+import PresetAmber from "postgraphile/presets/amber";
 import { makeV4Preset } from "postgraphile/presets/v4";
 
 /** @type {GraphileConfig.Preset} */
 const preset = {
   extends: [
-    postgraphilePresetAmber,
+    PresetAmber.default ?? PresetAmber,
     makeV4Preset({
       /* PUT YOUR V4 OPTIONS HERE */
       simpleCollections: "both",
@@ -170,13 +170,15 @@ returns an object that contains the middleware under the `handler` key. Here's a
 simple example:
 
 ```ts title="server.js"
-import config from "./graphile.config.js";
+import preset from "./graphile.config.js";
 import { postgraphile } from "postgraphile";
+import { grafserv } from "grafserv/node";
 import { createServer } from "node:http";
 
-const instance = postgraphile(config);
+const pgl = postgraphile(preset);
+const serv = pgl.createServ(grafserv);
 
-const server = createServer(instance.handler);
+const server = createServer(serv.createHander());
 server.on("error", (e) => console.error(e));
 server.listen(port);
 ```
@@ -190,10 +192,10 @@ lifecycle that needs to be carefully managed - just run the query through
 ```ts title="schema-only.js"
 import { grafast, hookArgs } from "grafast";
 import { makeSchema } from "postgraphile";
-import config from "./graphile.config.js";
+import preset from "./graphile.config.js";
 
 async function main() {
-  const { schema, resolvedPreset } = await makeSchema(config);
+  const { schema, resolvedPreset } = await makeSchema(preset);
 
   const args = {
     schema,
@@ -379,10 +381,10 @@ and finally comes the shared object which contains inflection.
 ```js
 const preset = require("./graphile.config.js");
 
-const config = resolvePresets([preset]);
-const shared = { inflection: buildInflection(config) };
-const input = await gather(config, shared);
-const schema = buildSchema(config, input, shared);
+const resolvedPreset = resolvePresets([preset]);
+const shared = { inflection: buildInflection(resolvedPreset) };
+const input = await gather(resolvedPreset, shared);
+const schema = buildSchema(resolvedPreset, input, shared);
 ```
 
 ## `postgraphile-core`
@@ -406,9 +408,9 @@ const gqlSchema = await createPostGraphileSchema(DATABASE_URL, "public", {
 
 ```js
 import { makeSchema } from "postgraphile";
-import config from "./graphile.config.js";
+import preset from "./graphile.config.js";
 
-const { schema, contextCallback } = await makeSchema(config);
+const { schema, contextCallback } = await makeSchema(preset);
 ```
 
 [grafast]: https://grafast.org


### PR DESCRIPTION
- `instance` no longer used for `const instance = postgraphile(...)` or `const instance = grafserv(...)`; instead `pgl` and `serv` are used respectively
- `getGrafserv()` doesn't exist any more, so new `createServ()` API has been documented instead
- update V4 migration guide to use the new APIs