### PR TITLE
Fix Ruru on alternative paths

### DIFF
--- a/grafast/grafserv/src/middleware/graphiql.ts
+++ b/grafast/grafserv/src/middleware/graphiql.ts
@@ -2,7 +2,8 @@ import type { HandlerResult, NormalizedRequestDigest } from "../interfaces.js";
 import type { OptionsFromConfig } from "../options.js";
 
 const ruruServer = import("ruru/server");
-let ruruHTML: Awaited<typeof ruruServer>["ruruHTML"] | undefined = undefined;
+type RuruHTMLFunction = Awaited<typeof ruruServer>["ruruHTML"];
+let ruruHTML: RuruHTMLFunction | undefined = undefined;
 
 // TODO: use a specific version of mermaid
 export function makeGraphiQLHandler(
@@ -13,7 +14,16 @@ export function makeGraphiQLHandler(
     if (!ruruHTML) {
       ruruHTML = (await ruruServer).ruruHTML;
     }
-    const config = {};
+    const config: Parameters<RuruHTMLFunction>[0] = {
+      endpoint: dynamicOptions.graphqlPath,
+      // TODO: websocket endpoint
+      debugTools:
+        dynamicOptions.explain === true
+          ? ["explain", "plan"]
+          : dynamicOptions.explain === false
+          ? []
+          : (dynamicOptions.explain as any[]),
+    };
     return {
       statusCode: 200,
       request,

--- a/grafast/grafserv/src/options.ts
+++ b/grafast/grafserv/src/options.ts
@@ -11,6 +11,7 @@ export function optionsFromConfig(config: GraphileConfig.ResolvedPreset) {
     maxRequestLength = 100_000,
     outputDataAsString = false,
   } = config.server ?? {};
+  const { explain } = config.grafast ?? {};
   return {
     outputDataAsString,
     graphqlPath,
@@ -21,6 +22,7 @@ export function optionsFromConfig(config: GraphileConfig.ResolvedPreset) {
     watch,
     eventStreamRoute,
     maxRequestLength,
+    explain,
   };
 }
 export type OptionsFromConfig = ReturnType<typeof optionsFromConfig>;

--- a/postgraphile/postgraphile/graphile.config.mjs
+++ b/postgraphile/postgraphile/graphile.config.mjs
@@ -36,7 +36,9 @@ const preset = {
   inflection: {},
   gather: {},
   schema: {},
-  server: {},
+  server: {
+    graphqlPath: "/v2/graphql",
+  },
   grafast: {
     context: {
       mol: 42,


### PR DESCRIPTION
We weren't passing the options through to Ruru previously, so it didn't know that `/graphql` was no longer the expected endpoint.