### PR TITLE
Rename pgSources -> pgConfigs

### DIFF
--- a/graphile-build/graphile-build-pg/src/examples/benjies-test-script.ts
+++ b/graphile-build/graphile-build-pg/src/examples/benjies-test-script.ts
@@ -39,7 +39,7 @@ import { inspect } from "util";
 import * as ws from "ws";
 
 import { defaultPreset as graphileBuildPgPreset } from "../index.js";
-import { getWithPgClientFromPgSource } from "../pgSources.js";
+import { getWithPgClientFromPgConfig } from "../pgConfigs.js";
 
 declare global {
   namespace GraphileBuild {
@@ -65,7 +65,7 @@ pool.on("error", (e) => {
     {
       extends: [graphileBuildPreset, graphileBuildPgPreset],
       plugins: [QueryQueryPlugin, SwallowErrorsPlugin],
-      pgSources: [
+      pgConfigs: [
         {
           name: "main",
           schemas: ["a", "b", "c"],
@@ -129,7 +129,7 @@ pool.on("error", (e) => {
   const rootValue = null;
 
   const contextValue = {
-    withPgClient: getWithPgClientFromPgSource(config.pgSources![0]!),
+    withPgClient: getWithPgClientFromPgConfig(config.pgConfigs![0]!),
   };
 
   // Our operation requires no variables

--- a/graphile-build/graphile-build-pg/src/examples/config.ts
+++ b/graphile-build/graphile-build-pg/src/examples/config.ts
@@ -15,7 +15,7 @@ import {
 import { Pool } from "pg";
 
 import { defaultPreset as graphileBuildPgPreset } from "../index.js";
-import { getWithPgClientFromPgSource } from "../pgSources.js";
+import { getWithPgClientFromPgConfig } from "../pgConfigs.js";
 
 // You should set these to be the values you want to use for demonstration
 const DATABASE_CONNECTION_STRING = "postgres:///pagila";
@@ -71,7 +71,7 @@ export async function makeSharedPresetAndClient(pool: Pool) {
   const preset: GraphileConfig.Preset = {
     extends: [graphileBuildPreset, graphileBuildPgPreset],
     plugins: [QueryQueryPlugin, SwallowErrorsPlugin, EnumManglingPlugin],
-    pgSources: [
+    pgConfigs: [
       {
         name: "main",
         schemas: DATABASE_SCHEMAS,
@@ -91,7 +91,7 @@ export async function makeSharedPresetAndClient(pool: Pool) {
     },
   };
 
-  const withPgClient = await getWithPgClientFromPgSource(preset.pgSources![0]!);
+  const withPgClient = await getWithPgClientFromPgConfig(preset.pgConfigs![0]!);
 
   return {
     preset,

--- a/graphile-build/graphile-build-pg/src/examples/webpack.ts
+++ b/graphile-build/graphile-build-pg/src/examples/webpack.ts
@@ -50,7 +50,7 @@ async function main() {
     {
       extends: [graphileBuildPreset, graphileBuildPgPreset],
       plugins: [QueryQueryPlugin, SwallowErrorsPlugin],
-      pgSources: [
+      pgConfigs: [
         // Configuration of our main (and only) Postgres database
         {
           name: "main",

--- a/graphile-build/graphile-build-pg/src/index.ts
+++ b/graphile-build/graphile-build-pg/src/index.ts
@@ -8,9 +8,9 @@ export {
   PgTypeColumnTags,
 } from "./interfaces.js";
 export {
-  getWithPgClientFromPgSource,
-  withPgClientFromPgSource,
-} from "./pgSources.js";
+  getWithPgClientFromPgConfig,
+  withPgClientFromPgConfig,
+} from "./pgConfigs.js";
 export { PgAllRowsPlugin } from "./plugins/PgAllRowsPlugin.js";
 export { PgBasicsPlugin } from "./plugins/PgBasicsPlugin.js";
 export { PgCodecsPlugin } from "./plugins/PgCodecsPlugin.js";

--- a/graphile-build/graphile-build-pg/src/plugins/PgContextPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgContextPlugin.ts
@@ -1,7 +1,7 @@
 import type {} from "grafast";
 
 import { version } from "../index.js";
-import { withPgClientFromPgSource } from "../pgSources.js";
+import { withPgClientFromPgConfig } from "../pgConfigs.js";
 
 export const PgContextPlugin: GraphileConfig.Plugin = {
   name: "PgContextPlugin",
@@ -17,12 +17,12 @@ export const PgContextPlugin: GraphileConfig.Plugin = {
           args.contextValue = Object.create(null);
         }
         const contextValue = args.contextValue as Record<string, any>;
-        if (config.pgSources) {
-          for (const pgSource of config.pgSources) {
-            const { pgSettings, pgSettingsKey, withPgClientKey } = pgSource;
+        if (config.pgConfigs) {
+          for (const pgConfig of config.pgConfigs) {
+            const { pgSettings, pgSettingsKey, withPgClientKey } = pgConfig;
             if (pgSettings && pgSettingsKey == null) {
               throw new Error(
-                `pgSource '${pgSource.name}' specifies pgSettings, but has no pgSettingsKey.`,
+                `pgConfig '${pgConfig.name}' specifies pgSettings, but has no pgSettingsKey.`,
               );
             }
             if (pgSettingsKey != null) {
@@ -47,9 +47,9 @@ export const PgContextPlugin: GraphileConfig.Plugin = {
                 `Key '${withPgClientKey}' already set on the context; refusing to overwrite - please check your configuration.`,
               );
             }
-            contextValue[withPgClientKey] = withPgClientFromPgSource.bind(
+            contextValue[withPgClientKey] = withPgClientFromPgConfig.bind(
               null,
-              pgSource,
+              pgConfig,
             );
           }
         }

--- a/graphile-build/graphile-build-pg/src/plugins/PgEnumTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgEnumTablesPlugin.ts
@@ -9,7 +9,7 @@ import type {
 import { sql } from "pg-sql2";
 
 import { version } from "../index.js";
-import { withPgClientFromPgSource } from "../pgSources.js";
+import { withPgClientFromPgConfig } from "../pgConfigs.js";
 import { addBehaviorToTags } from "../utils.js";
 
 declare global {
@@ -109,12 +109,12 @@ export const PgEnumTablesPlugin: GraphileConfig.Plugin = {
           )};`,
         );
 
-        const database = info.resolvedPreset.pgSources!.find(
-          (database) => database.name === databaseName,
+        const pgConfig = info.resolvedPreset.pgConfigs!.find(
+          (pgConfig) => pgConfig.name === databaseName,
         );
         try {
-          const { rows } = await withPgClientFromPgSource(
-            database!,
+          const { rows } = await withPgClientFromPgConfig(
+            pgConfig!,
             null,
             (client) => client.query<Record<string, string>>(query),
           );
@@ -122,8 +122,8 @@ export const PgEnumTablesPlugin: GraphileConfig.Plugin = {
         } catch (e) {
           let role = "RELEVANT_POSTGRES_USER";
           try {
-            const { rows } = await withPgClientFromPgSource(
-              database!,
+            const { rows } = await withPgClientFromPgConfig(
+              pgConfig!,
               null,
               (client) =>
                 client.query<{ user: string }>({

--- a/graphile-build/graphile-build-pg/src/plugins/PgProceduresPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgProceduresPlugin.ts
@@ -153,15 +153,15 @@ export const PgProceduresPlugin: GraphileConfig.Plugin = {
           return source;
         }
         source = (async () => {
-          const database = info.resolvedPreset.pgSources?.find(
+          const pgConfig = info.resolvedPreset.pgConfigs?.find(
             (db) => db.name === databaseName,
           );
-          if (!database) {
+          if (!pgConfig) {
             throw new Error(
-              `Could not find database '${databaseName}' in pgSources`,
+              `Could not find pgConfig '${databaseName}' in pgConfigs`,
             );
           }
-          const schemas = database.schemas ?? ["public"];
+          const schemas = pgConfig.schemas ?? ["public"];
 
           const namespace = pgProc.getNamespace();
           if (!namespace) {
@@ -545,13 +545,13 @@ export const PgProceduresPlugin: GraphileConfig.Plugin = {
       async pgIntrospection_proc({ helpers, resolvedPreset }, event) {
         const { entity: pgProc, databaseName } = event;
 
-        const database = resolvedPreset.pgSources?.find(
+        const pgConfig = resolvedPreset.pgConfigs?.find(
           (db) => db.name === databaseName,
         );
-        if (!database) {
-          throw new Error(`Could not find '${databaseName}' in 'pgSources'`);
+        if (!pgConfig) {
+          throw new Error(`Could not find '${databaseName}' in 'pgConfigs'`);
         }
-        const schemas = database.schemas ?? ["public"];
+        const schemas = pgConfig.schemas ?? ["public"];
 
         // Only process procedures from one of the published namespaces
         const namespace = pgProc.getNamespace();
@@ -563,7 +563,7 @@ export const PgProceduresPlugin: GraphileConfig.Plugin = {
         // functions that really don’t need to be exposed in an API.
         const introspection = (
           await helpers.pgIntrospection.getIntrospection()
-        ).find((n) => n.database.name === databaseName)!.introspection;
+        ).find((n) => n.pgConfig.name === databaseName)!.introspection;
         const rangeType = introspection.types.find(
           (t) =>
             t.typnamespace === pgProc.pronamespace &&

--- a/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
@@ -253,13 +253,13 @@ export const PgTablesPlugin: GraphileConfig.Plugin = {
   inflection: {
     add: {
       _schemaPrefix(options, { pgNamespace, databaseName }) {
-        const database = options.pgSources?.find(
+        const pgConfig = options.pgConfigs?.find(
           (db) => db.name === databaseName,
         );
         const databasePrefix =
-          databaseName === database?.name ? "" : `${databaseName}-`;
+          databaseName === pgConfig?.name ? "" : `${databaseName}-`;
         const schemaPrefix =
-          pgNamespace.nspname === database?.schemas?.[0]
+          pgNamespace.nspname === pgConfig?.schemas?.[0]
             ? ""
             : `${pgNamespace.nspname}-`;
         return `${databasePrefix}${schemaPrefix}`;
@@ -372,13 +372,13 @@ export const PgTablesPlugin: GraphileConfig.Plugin = {
           return sourceBuilder;
         }
         sourceBuilder = (async () => {
-          const database = info.resolvedPreset.pgSources?.find(
+          const pgConfig = info.resolvedPreset.pgConfigs?.find(
             (db) => db.name === databaseName,
           );
-          if (!database) {
-            throw new Error(`Could not find '${databaseName}' in 'pgSources'`);
+          if (!pgConfig) {
+            throw new Error(`Could not find '${databaseName}' in 'pgConfigs'`);
           }
-          const schemas = database.schemas ?? ["public"];
+          const schemas = pgConfig.schemas ?? ["public"];
 
           const namespace = pgClass.getNamespace();
           if (!namespace) {

--- a/graphile-build/graphile-simplify-inflection/test.js
+++ b/graphile-build/graphile-simplify-inflection/test.js
@@ -3,7 +3,7 @@ const pg = require("pg");
 const fsp = require("fs").promises;
 const child_process = require("child_process");
 const { PgSimplifyInflectionPreset } = require("./dist/index.js");
-const { makeSchema, makePgSources } = require("postgraphile");
+const { makeSchema, makePgConfigs } = require("postgraphile");
 const { postgraphilePresetAmber } = require("postgraphile/presets/amber");
 const { makeV4Preset } = require("postgraphile/presets/v4");
 const { printSchema, lexicographicSortSchema } = require("graphql");
@@ -66,7 +66,7 @@ async function getSettings(dir) {
 }
 
 async function getSchema(client, withSimplify, settings) {
-  const pgSources = makePgSources(CONNECTION_STRING, "app_public");
+  const pgConfigs = makePgConfigs(CONNECTION_STRING, "app_public");
   const result = await makeSchema({
     extends: [
       postgraphilePresetAmber,
@@ -76,11 +76,11 @@ async function getSchema(client, withSimplify, settings) {
       }),
       ...(withSimplify ? [PgSimplifyInflectionPreset] : []),
     ],
-    pgSources,
+    pgConfigs,
   });
   // TODO: solve this better!
   // Hack to release the pool
-  pgSources[0].adaptorSettings.pool.end();
+  pgConfigs[0].adaptorSettings.pool.end();
   return result.schema;
 }
 

--- a/postgraphile/postgraphile/__tests__/helpers.ts
+++ b/postgraphile/postgraphile/__tests__/helpers.ts
@@ -204,7 +204,7 @@ export async function runTestQuery(
   const preset: GraphileConfig.Preset = {
     extends: [AmberPreset],
     plugins: [StreamDeferPlugin],
-    pgSources: [
+    pgConfigs: [
       {
         adaptor: "@dataplan/pg/adaptors/node-postgres",
         name: "main",

--- a/postgraphile/postgraphile/__tests__/schema/v4/core.ts
+++ b/postgraphile/postgraphile/__tests__/schema/v4/core.ts
@@ -38,7 +38,7 @@ export const test =
       const graphileBuildOptions = {};
       const preset: GraphileConfig.Preset = {
         extends: [AmberPreset, v4Preset],
-        pgSources: [
+        pgConfigs: [
           {
             adaptor: "@dataplan/pg/adaptors/node-postgres",
             name: "main",

--- a/postgraphile/postgraphile/src/cli.ts
+++ b/postgraphile/postgraphile/src/cli.ts
@@ -6,7 +6,7 @@ import { createServer } from "node:http";
 import { inspect } from "node:util";
 
 import { postgraphile } from "./index.js";
-import { makePgSources } from "./schema.js";
+import { makePgConfigs } from "./schema.js";
 
 // The preset we recommend if the user doesn't specify one
 const RECOMMENDED_PRESET = "--preset postgraphile/presets/amber";
@@ -158,8 +158,8 @@ export async function run(args: ArgsFromOptions<typeof options>) {
   // Apply CLI options to preset
   if (connectionString || rawSchema) {
     const schemas = rawSchema?.split(",") ?? ["public"];
-    const newPgSources = makePgSources(connectionString, schemas);
-    preset.pgSources = newPgSources;
+    const newPgConfigs = makePgConfigs(connectionString, schemas);
+    preset.pgConfigs = newPgConfigs;
   }
   preset.server = preset.server || {};
   if (rawPort != null) {
@@ -177,7 +177,7 @@ export async function run(args: ArgsFromOptions<typeof options>) {
   }
 
   const config = resolvePresets([preset]);
-  if (!config.pgSources || config.pgSources.length === 0) {
+  if (!config.pgConfigs || config.pgConfigs.length === 0) {
     // TODO: respect envvars here?
     console.error(
       `ERROR: Please specify \`--connection\` so we know which database to connect to (or add details to your \`graphile.config.js\`):\n\n  postgraphile${

--- a/postgraphile/postgraphile/src/index.ts
+++ b/postgraphile/postgraphile/src/index.ts
@@ -11,7 +11,7 @@ import type { GraphQLSchema } from "graphql";
 import type { ServerParams } from "./interfaces.js";
 import { makeSchema, watchSchema } from "./schema.js";
 
-export { makePgSources, makeSchema } from "./schema.js";
+export { makePgConfigs, makeSchema } from "./schema.js";
 
 export { GraphileBuild, GraphileConfig };
 

--- a/postgraphile/postgraphile/src/schema.ts
+++ b/postgraphile/postgraphile/src/schema.ts
@@ -25,7 +25,7 @@ declare global {
   }
 }
 
-export function makePgSources(
+export function makePgConfigs(
   connectionString?: string,
   schemas?: string | string[],
 ): ReadonlyArray<GraphileConfig.PgDatabaseConfiguration> {

--- a/postgraphile/website/postgraphile/config.md
+++ b/postgraphile/website/postgraphile/config.md
@@ -32,7 +32,7 @@ if the same plugin is referenced in multiple presets.
 The preset also accepts keys for each supported scope. `graphile-config` has no
 native scopes, but different Graphile projects can register their own scopes,
 for example `graphile-build` registers the `inflection`, `gather` and `schema`
-scopes, `graphile-build-pg` registers the `pgSources` scope, and PostGraphile
+scopes, `graphile-build-pg` registers the `pgConfigs` scope, and PostGraphile
 registers the `server` scope.
 
 We highly recommend using TypeScript for dealing with your preset so that you
@@ -54,7 +54,7 @@ import "postgraphile";
 
 import amber from "postgraphile/presets/amber";
 import { StreamDeferPlugin } from "graphile-build";
-import { makePgSources } from "postgraphile";
+import { makePgConfigs } from "postgraphile";
 
 /** @type {GraphileConfig.Preset} */
 const preset = {
@@ -71,9 +71,9 @@ const preset = {
   inflection: {
     /* options for the inflection system */
   },
-  pgSources: [
+  pgConfigs: [
     /* list of PG database configurations, e.g.: */
-    ...makePgSources(
+    ...makePgConfigs(
       // Database connection string:
       process.env.DATABASE_URL,
       // List of schemas to expose:
@@ -103,7 +103,7 @@ _(TypeScript type: `GraphileBuild.GraphileBuildInflectionOptions`)_
 
 _None at this time._
 
-## `pgSources`
+## `pgConfigs`
 
 _(TypeScript type: `ReadonlyArray<GraphileConfig.PgDatabaseConfiguration>`)_
 
@@ -111,11 +111,11 @@ Details the PostgreSQL database(s) for PostGraphile to connect to; this is a
 separate option because it's used in both the `gather` phase (for introspection)
 and at runtime.
 
-Generally it's best to construct this by using the `makePgSources` helper (see
+Generally it's best to construct this by using the `makePgConfigs` helper (see
 below), but if you want to know the nitty-gritty: each entry in the list is an
 object with the following keys (only `name` and `adaptor` are required):
 
-- `name: string` - an arbitrary unique name for this source; please keep it
+- `name: string` - an arbitrary unique name for this config; please keep it
   alphanumeric!
 - `adaptor: string` - the name of the module to use as the postgres adaptor;
   e.g. `@dataplan/pg/adaptors/node-postgres` for the `pg` module
@@ -138,7 +138,7 @@ object with the following keys (only `name` and `adaptor` are required):
 ```js title="Example manual configuration"
 import * as pg from "pg";
 
-const pgSources = [
+const pgConfigs = [
   {
     name: "main",
     schemas: ["app_public"],
@@ -152,11 +152,11 @@ const pgSources = [
 ];
 ```
 
-### `makePgSources`
+### `makePgConfigs`
 
 This simple function will take a PostgreSQL connection string and a list of
 schemas and will return an array containing a configuration object suitable for
-inclusion in `pgSources`.
+inclusion in `pgConfigs`.
 
 :::info
 
@@ -165,8 +165,8 @@ that default over time.
 
 :::
 
-```js title="Example configuration via makePgSources"
-const pgSources = makePgSources(process.env.DATABASE_URL, ["app_public"]);
+```js title="Example configuration via makePgConfigs"
+const pgConfigs = makePgConfigs(process.env.DATABASE_URL, ["app_public"]);
 ```
 
 ## `gather` options
@@ -298,7 +298,7 @@ for realtime). Instead, add helpers to get/set the data you need.
 
 ### Exposing HTTP request data to PostgreSQL
 
-Using the `pgSettings` functionality mentioned in the `pgSources` section above
+Using the `pgSettings` functionality mentioned in the `pgConfigs` section above
 you can extend the data made available within PostgreSQL through
 `current_setting(...)`. To do so, include a `pgSettings` entry in the GraphQL
 context mentioned in the "Grafast options" section above, the value for which

--- a/postgraphile/website/postgraphile/migrating-from-v4/index.md
+++ b/postgraphile/website/postgraphile/migrating-from-v4/index.md
@@ -52,7 +52,7 @@ initial preset) to get a completed config:
 ```ts title="graphile.config.js"
 import "graphile-config";
 
-import { makePgSources } from "postgraphile";
+import { makePgConfigs } from "postgraphile";
 import PresetAmber from "postgraphile/presets/amber";
 import { makeV4Preset } from "postgraphile/presets/v4";
 
@@ -75,7 +75,7 @@ const preset = {
   // If you're using the CLI you can skip this and use the `-c` and `-s`
   // options instead, but we advise configuring it here so all the modes of
   // running PostGraphile can share it.
-  pgSources: makePgSources(
+  pgConfigs: makePgConfigs(
     // Database connection string:
     process.env.DATABASE_URL,
     // List of schemas to expose:

--- a/postgraphile/website/postgraphile/usage-cli.mdx
+++ b/postgraphile/website/postgraphile/usage-cli.mdx
@@ -54,12 +54,12 @@ you can run PostGraphile with no (or minimal) CLI flags.
   enables "explain" mode, you won't want this in production but it's very helpful
   in development to know what's going on
 - `--connection <string>` (alias: `-c`)
-  <equivalent>{`{ pgSources: makePgSources('...') }`}</equivalent>
+  <equivalent>{`{ pgConfigs: makePgConfigs('...') }`}</equivalent>
   the PostgreSQL connection string. If omitted, inferred from environmental variables
   (see https://www.postgresql.org/docs/current/static/libpq-envars.html). Examples:
   'db', 'postgres:///db', 'postgres://user:password@domain:port/db?ssl=true'
 - `--schema <string>` (alias: `-s`)
-  <equivalent>{`{ pgSources: makePgSources(databaseUrl, ['...']) }`}</equivalent>
+  <equivalent>{`{ pgConfigs: makePgConfigs(databaseUrl, ['...']) }`}</equivalent>
   a comma-separated list of PostgreSQL schemas to be introspected.
 - `--watch` (alias: `-w`)
   <equivalent>{`{ server: { watch: true } }`}</equivalent>


### PR DESCRIPTION
A `PgSource` represents a single table/function/similar from which we can get data.

A `GraphileConfig.PgDatabaseConfiguration` represents a single database connection, which can be shared across many PgSources. Most PostGraphile instances only need one `GraphileConfig.PgDatabaseConfiguration`.

Previously we were using `pgSources: GraphileConfig.PgDatabaseConfiguration[]` on the preset, and `pgSources: PgSource[]` on the build input. Very confusing!

This PR splits these two concepts up by renaming the `GraphileConfig.PgDatabaseConfiguration` entries to `pgConfigs`. It also renames some instances of the word `database` in the codebase to be `pgConfig` if that's actually what that variable is.

🚨 If you have `pgSources:` in your config, you'll need to rename that to `pgConfigs`. Similarly all the related functions have been renamed (`makePgSources` -> `makePgConfigs`).

Relates to #166