### PR TITLE
Fix applying lists of input objects

### DIFF
--- a/grafast/grafast/src/operationPlan-input.ts
+++ b/grafast/grafast/src/operationPlan-input.ts
@@ -303,16 +303,9 @@ export function withFieldArgsForArguments<
                   )
                 : undefined;
             } else {
-              // Something inside a list
-              const nullableType = getNullableType(entityType);
-              if (isInputObjectType(nullableType)) {
-                const fields = nullableType.getFields();
-                for (const fieldName of Object.keys(fields)) {
-                  fieldArgs.apply($target, [...path, fieldName]);
-                }
-                // Shortcut 'processAfter'
-                return;
-              }
+              childFieldArgs.apply($target);
+              // Shortcut 'processAfter'
+              return;
             }
             const nullableType = getNullableType(entityType);
             if (isInputObjectType(nullableType)) {


### PR DESCRIPTION
This fixes a bug that affected `postgraphile-plugin-connection-filter` and prevented `and` and `or` filters from working.

No changeset because we never released a version that had this bug.