### PR TITLE
Use safe access in access step

### DIFF
--- a/.changeset/hip-scissors-learn.md
+++ b/.changeset/hip-scissors-learn.md
@@ -1,0 +1,5 @@
+---
+"grafast": patch
+---
+
+Fix access step to use safe access pattern even when compiled

--- a/grafast/grafast/src/steps/access.ts
+++ b/grafast/grafast/src/steps/access.ts
@@ -35,7 +35,7 @@ function constructDestructureFunction(
 ): void {
   const n = path.length;
   /** 0 - slow mode; 1 - middle mode; 2 - turbo mode */
-  let mode: 0 | 1 | 2 = n > 50 ? 0 : n > 5 ? 1 : 2;
+  let mode: 0 | 1 | 2 = n > 50 || n < 1 ? 0 : n > 5 ? 1 : 2;
 
   for (let i = 0; i < n; i++) {
     const pathItem = path[i];
@@ -110,7 +110,7 @@ function constructDestructureFunction(
     }
     te.runInBatch<Factory>(
       te`function (fallback, ${te.join(names, ", ")}) {
-return (_meta, value) => value${te.join(access, "")}${
+return (_meta, value) => value?.${te.join(access, "?.")}${
         fallback === undefined ? te.blank : te.cache` ?? fallback`
       };
 }`,

--- a/postgraphile/postgraphile/__tests__/queries/v4/rbac.basic.json5
+++ b/postgraphile/postgraphile/__tests__/queries/v4/rbac.basic.json5
@@ -32,6 +32,7 @@
     nodeId: "WyJwZW9wbGUiLDFd",
     personSecretByPersonId: null,
   },
+  nxPerson: null,
   leftArmById: {
     nodeId: "WyJsZWZ0X2FybXMiLDQyXQ==",
     id: 42,

--- a/postgraphile/postgraphile/__tests__/queries/v4/rbac.basic.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/rbac.basic.mermaid
@@ -14,22 +14,25 @@ graph TD
     Access10{{"Access[10∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     PgSelect8[["PgSelect[8∈0]<br />ᐸperson_secretᐳ"]]:::plan
-    Constant219{{"Constant[219∈0]<br />ᐸ3ᐳ"}}:::plan
-    Object11 & Constant219 --> PgSelect8
+    Constant245{{"Constant[245∈0]<br />ᐸ3ᐳ"}}:::plan
+    Object11 & Constant245 --> PgSelect8
     PgSelect43[["PgSelect[43∈0]<br />ᐸpersonᐳ"]]:::plan
-    Constant220{{"Constant[220∈0]<br />ᐸ1ᐳ"}}:::plan
-    Object11 & Constant220 --> PgSelect43
-    PgSelect67[["PgSelect[67∈0]<br />ᐸleft_armᐳ"]]:::plan
-    Constant221{{"Constant[221∈0]<br />ᐸ42ᐳ"}}:::plan
-    Object11 & Constant221 --> PgSelect67
-    PgSelect106[["PgSelect[106∈0]<br />ᐸpersonᐳ"]]:::plan
-    Constant222{{"Constant[222∈0]<br />ᐸ2ᐳ"}}:::plan
-    Object11 & Constant222 --> PgSelect106
-    PgSelect132[["PgSelect[132∈0]<br />ᐸpostᐳ"]]:::plan
-    Constant223{{"Constant[223∈0]<br />ᐸ7ᐳ"}}:::plan
-    Object11 & Constant223 --> PgSelect132
-    PgSelect171[["PgSelect[171∈0]<br />ᐸpersonᐳ"]]:::plan
-    Object11 & Constant219 --> PgSelect171
+    Constant246{{"Constant[246∈0]<br />ᐸ1ᐳ"}}:::plan
+    Object11 & Constant246 --> PgSelect43
+    PgSelect67[["PgSelect[67∈0]<br />ᐸpersonᐳ"]]:::plan
+    Constant247{{"Constant[247∈0]<br />ᐸ12345678ᐳ"}}:::plan
+    Object11 & Constant247 --> PgSelect67
+    PgSelect91[["PgSelect[91∈0]<br />ᐸleft_armᐳ"]]:::plan
+    Constant248{{"Constant[248∈0]<br />ᐸ42ᐳ"}}:::plan
+    Object11 & Constant248 --> PgSelect91
+    PgSelect130[["PgSelect[130∈0]<br />ᐸpersonᐳ"]]:::plan
+    Constant249{{"Constant[249∈0]<br />ᐸ2ᐳ"}}:::plan
+    Object11 & Constant249 --> PgSelect130
+    PgSelect156[["PgSelect[156∈0]<br />ᐸpostᐳ"]]:::plan
+    Constant250{{"Constant[250∈0]<br />ᐸ7ᐳ"}}:::plan
+    Object11 & Constant250 --> PgSelect156
+    PgSelect195[["PgSelect[195∈0]<br />ᐸpersonᐳ"]]:::plan
+    Object11 & Constant245 --> PgSelect195
     __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
     __Value3 --> Access9
     __Value3 --> Access10
@@ -43,84 +46,96 @@ graph TD
     First47 --> PgSelectSingle48
     First71{{"First[71∈0]"}}:::plan
     PgSelect67 --> First71
-    PgSelectSingle72{{"PgSelectSingle[72∈0]<br />ᐸleft_armᐳ"}}:::plan
+    PgSelectSingle72{{"PgSelectSingle[72∈0]<br />ᐸpersonᐳ"}}:::plan
     First71 --> PgSelectSingle72
-    First110{{"First[110∈0]"}}:::plan
-    PgSelect106 --> First110
-    PgSelectSingle111{{"PgSelectSingle[111∈0]<br />ᐸpersonᐳ"}}:::plan
-    First110 --> PgSelectSingle111
-    First136{{"First[136∈0]"}}:::plan
-    PgSelect132 --> First136
-    PgSelectSingle137{{"PgSelectSingle[137∈0]<br />ᐸpostᐳ"}}:::plan
-    First136 --> PgSelectSingle137
-    First175{{"First[175∈0]"}}:::plan
-    PgSelect171 --> First175
-    PgSelectSingle176{{"PgSelectSingle[176∈0]<br />ᐸpersonᐳ"}}:::plan
-    First175 --> PgSelectSingle176
-    PgSelect206[["PgSelect[206∈0]<br />ᐸreturn_table_without_grantsᐳ"]]:::plan
-    Object11 --> PgSelect206
-    First210{{"First[210∈0]"}}:::plan
-    PgSelect206 --> First210
-    PgSelectSingle211{{"PgSelectSingle[211∈0]<br />ᐸreturn_table_without_grantsᐳ"}}:::plan
-    First210 --> PgSelectSingle211
+    First95{{"First[95∈0]"}}:::plan
+    PgSelect91 --> First95
+    PgSelectSingle96{{"PgSelectSingle[96∈0]<br />ᐸleft_armᐳ"}}:::plan
+    First95 --> PgSelectSingle96
+    First134{{"First[134∈0]"}}:::plan
+    PgSelect130 --> First134
+    PgSelectSingle135{{"PgSelectSingle[135∈0]<br />ᐸpersonᐳ"}}:::plan
+    First134 --> PgSelectSingle135
+    First160{{"First[160∈0]"}}:::plan
+    PgSelect156 --> First160
+    PgSelectSingle161{{"PgSelectSingle[161∈0]<br />ᐸpostᐳ"}}:::plan
+    First160 --> PgSelectSingle161
+    First199{{"First[199∈0]"}}:::plan
+    PgSelect195 --> First199
+    PgSelectSingle200{{"PgSelectSingle[200∈0]<br />ᐸpersonᐳ"}}:::plan
+    First199 --> PgSelectSingle200
+    PgSelect230[["PgSelect[230∈0]<br />ᐸreturn_table_without_grantsᐳ"]]:::plan
+    Object11 --> PgSelect230
+    First234{{"First[234∈0]"}}:::plan
+    PgSelect230 --> First234
+    PgSelectSingle235{{"PgSelectSingle[235∈0]<br />ᐸreturn_table_without_grantsᐳ"}}:::plan
+    First234 --> PgSelectSingle235
     __Value0["__Value[0∈0]"]:::plan
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
     Constant14{{"Constant[14∈0]<br />ᐸ'person_secrets'ᐳ"}}:::plan
     Connection32{{"Connection[32∈0]<br />ᐸ28ᐳ"}}:::plan
     Constant49{{"Constant[49∈0]<br />ᐸ'people'ᐳ"}}:::plan
-    Constant73{{"Constant[73∈0]<br />ᐸ'left_arms'ᐳ"}}:::plan
-    Connection93{{"Connection[93∈0]<br />ᐸ89ᐳ"}}:::plan
-    Constant138{{"Constant[138∈0]<br />ᐸ'posts'ᐳ"}}:::plan
-    Connection158{{"Connection[158∈0]<br />ᐸ154ᐳ"}}:::plan
-    PgClassExpression212{{"PgClassExpression[212∈20]<br />ᐸ__return_t...rson_id_1”ᐳ"}}:::plan
-    PgSelectSingle211 --> PgClassExpression212
-    PgClassExpression213{{"PgClassExpression[213∈20]<br />ᐸ__return_t...rson_id_2”ᐳ"}}:::plan
-    PgSelectSingle211 --> PgClassExpression213
-    List179{{"List[179∈17]<br />ᐸ49,178ᐳ"}}:::plan
-    PgClassExpression178{{"PgClassExpression[178∈17]<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Constant49 & PgClassExpression178 --> List179
-    PgSelectSingle176 --> PgClassExpression178
-    Lambda180{{"Lambda[180∈17]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List179 --> Lambda180
-    Access218{{"Access[218∈17]<br />ᐸ175.0ᐳ"}}:::plan
-    First175 --> Access218
-    Connection194{{"Connection[194∈17]<br />ᐸ190ᐳ"}}:::plan
-    PgSelect159[["PgSelect[159∈14]<br />ᐸpostᐳ"]]:::plan
-    Object11 & Connection158 --> PgSelect159
-    List140{{"List[140∈13]<br />ᐸ138,139ᐳ"}}:::plan
-    PgClassExpression139{{"PgClassExpression[139∈13]<br />ᐸ__post__.”id”ᐳ"}}:::plan
-    Constant138 & PgClassExpression139 --> List140
-    PgSelectSingle137 --> PgClassExpression139
-    Lambda141{{"Lambda[141∈13]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List140 --> Lambda141
-    PgClassExpression143{{"PgClassExpression[143∈13]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
-    PgSelectSingle137 --> PgClassExpression143
-    PgClassExpression144{{"PgClassExpression[144∈13]<br />ᐸ__post__.”body”ᐳ"}}:::plan
-    PgSelectSingle137 --> PgClassExpression144
-    PgClassExpression145{{"PgClassExpression[145∈13]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
-    PgSelectSingle137 --> PgClassExpression145
-    List114{{"List[114∈11]<br />ᐸ49,113ᐳ"}}:::plan
-    PgClassExpression113{{"PgClassExpression[113∈11]<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Constant49 & PgClassExpression113 --> List114
-    PgSelectSingle111 --> PgClassExpression113
-    Lambda115{{"Lambda[115∈11]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List114 --> Lambda115
-    PgSelectSingle122{{"PgSelectSingle[122∈11]<br />ᐸleft_armᐳ"}}:::plan
-    PgSelectSingle111 --> PgSelectSingle122
-    PgSelect94[["PgSelect[94∈8]<br />ᐸleft_armᐳ"]]:::plan
-    Object11 & Connection93 --> PgSelect94
-    List75{{"List[75∈7]<br />ᐸ73,74ᐳ"}}:::plan
-    PgClassExpression74{{"PgClassExpression[74∈7]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
-    Constant73 & PgClassExpression74 --> List75
+    Constant97{{"Constant[97∈0]<br />ᐸ'left_arms'ᐳ"}}:::plan
+    Connection117{{"Connection[117∈0]<br />ᐸ113ᐳ"}}:::plan
+    Constant162{{"Constant[162∈0]<br />ᐸ'posts'ᐳ"}}:::plan
+    Connection182{{"Connection[182∈0]<br />ᐸ178ᐳ"}}:::plan
+    PgClassExpression236{{"PgClassExpression[236∈22]<br />ᐸ__return_t...rson_id_1”ᐳ"}}:::plan
+    PgSelectSingle235 --> PgClassExpression236
+    PgClassExpression237{{"PgClassExpression[237∈22]<br />ᐸ__return_t...rson_id_2”ᐳ"}}:::plan
+    PgSelectSingle235 --> PgClassExpression237
+    List203{{"List[203∈19]<br />ᐸ49,202ᐳ"}}:::plan
+    PgClassExpression202{{"PgClassExpression[202∈19]<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant49 & PgClassExpression202 --> List203
+    PgSelectSingle200 --> PgClassExpression202
+    Lambda204{{"Lambda[204∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List203 --> Lambda204
+    Access244{{"Access[244∈19]<br />ᐸ199.0ᐳ"}}:::plan
+    First199 --> Access244
+    Connection218{{"Connection[218∈19]<br />ᐸ214ᐳ"}}:::plan
+    PgSelect183[["PgSelect[183∈16]<br />ᐸpostᐳ"]]:::plan
+    Object11 & Connection182 --> PgSelect183
+    List164{{"List[164∈15]<br />ᐸ162,163ᐳ"}}:::plan
+    PgClassExpression163{{"PgClassExpression[163∈15]<br />ᐸ__post__.”id”ᐳ"}}:::plan
+    Constant162 & PgClassExpression163 --> List164
+    PgSelectSingle161 --> PgClassExpression163
+    Lambda165{{"Lambda[165∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List164 --> Lambda165
+    PgClassExpression167{{"PgClassExpression[167∈15]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
+    PgSelectSingle161 --> PgClassExpression167
+    PgClassExpression168{{"PgClassExpression[168∈15]<br />ᐸ__post__.”body”ᐳ"}}:::plan
+    PgSelectSingle161 --> PgClassExpression168
+    PgClassExpression169{{"PgClassExpression[169∈15]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
+    PgSelectSingle161 --> PgClassExpression169
+    List138{{"List[138∈13]<br />ᐸ49,137ᐳ"}}:::plan
+    PgClassExpression137{{"PgClassExpression[137∈13]<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant49 & PgClassExpression137 --> List138
+    PgSelectSingle135 --> PgClassExpression137
+    Lambda139{{"Lambda[139∈13]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List138 --> Lambda139
+    PgSelectSingle146{{"PgSelectSingle[146∈13]<br />ᐸleft_armᐳ"}}:::plan
+    PgSelectSingle135 --> PgSelectSingle146
+    PgSelect118[["PgSelect[118∈10]<br />ᐸleft_armᐳ"]]:::plan
+    Object11 & Connection117 --> PgSelect118
+    List99{{"List[99∈9]<br />ᐸ97,98ᐳ"}}:::plan
+    PgClassExpression98{{"PgClassExpression[98∈9]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
+    Constant97 & PgClassExpression98 --> List99
+    PgSelectSingle96 --> PgClassExpression98
+    Lambda100{{"Lambda[100∈9]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List99 --> Lambda100
+    PgClassExpression102{{"PgClassExpression[102∈9]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
+    PgSelectSingle96 --> PgClassExpression102
+    PgClassExpression103{{"PgClassExpression[103∈9]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
+    PgSelectSingle96 --> PgClassExpression103
+    PgClassExpression104{{"PgClassExpression[104∈9]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
+    PgSelectSingle96 --> PgClassExpression104
+    List75{{"List[75∈7]<br />ᐸ49,74ᐳ"}}:::plan
+    PgClassExpression74{{"PgClassExpression[74∈7]<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant49 & PgClassExpression74 --> List75
     PgSelectSingle72 --> PgClassExpression74
     Lambda76{{"Lambda[76∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List75 --> Lambda76
-    PgClassExpression78{{"PgClassExpression[78∈7]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
-    PgSelectSingle72 --> PgClassExpression78
-    PgClassExpression79{{"PgClassExpression[79∈7]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
-    PgSelectSingle72 --> PgClassExpression79
-    PgClassExpression80{{"PgClassExpression[80∈7]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
-    PgSelectSingle72 --> PgClassExpression80
+    PgSelectSingle83{{"PgSelectSingle[83∈7]<br />ᐸperson_secretᐳ"}}:::plan
+    PgSelectSingle72 --> PgSelectSingle83
     List51{{"List[51∈5]<br />ᐸ49,50ᐳ"}}:::plan
     PgClassExpression50{{"PgClassExpression[50∈5]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant49 & PgClassExpression50 --> List51
@@ -142,9 +157,12 @@ graph TD
     List62{{"List[62∈6]<br />ᐸ14,61ᐳ"}}:::plan
     PgClassExpression61{{"PgClassExpression[61∈6]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant14 & PgClassExpression61 --> List62
-    List125{{"List[125∈12]<br />ᐸ73,124ᐳ"}}:::plan
-    PgClassExpression124{{"PgClassExpression[124∈12]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
-    Constant73 & PgClassExpression124 --> List125
+    List86{{"List[86∈8]<br />ᐸ14,85ᐳ"}}:::plan
+    PgClassExpression85{{"PgClassExpression[85∈8]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
+    Constant14 & PgClassExpression85 --> List86
+    List149{{"List[149∈14]<br />ᐸ97,148ᐳ"}}:::plan
+    PgClassExpression148{{"PgClassExpression[148∈14]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
+    Constant97 & PgClassExpression148 --> List149
     __Item34[/"__Item[34∈3]<br />ᐸ33ᐳ"\]:::itemplan
     PgSelect33 ==> __Item34
     PgSelectSingle35{{"PgSelectSingle[35∈3]<br />ᐸperson_secretᐳ"}}:::plan
@@ -154,78 +172,83 @@ graph TD
     List62 --> Lambda63
     PgClassExpression65{{"PgClassExpression[65∈6]<br />ᐸ__person_s..._.”sekrit”ᐳ"}}:::plan
     PgSelectSingle59 --> PgClassExpression65
-    __Item95[/"__Item[95∈9]<br />ᐸ94ᐳ"\]:::itemplan
-    PgSelect94 ==> __Item95
-    PgSelectSingle96{{"PgSelectSingle[96∈9]<br />ᐸleft_armᐳ"}}:::plan
-    __Item95 --> PgSelectSingle96
-    PgSelectSingle122 --> PgClassExpression124
-    Lambda126{{"Lambda[126∈12]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List125 --> Lambda126
-    PgClassExpression128{{"PgClassExpression[128∈12]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
-    PgSelectSingle122 --> PgClassExpression128
-    PgClassExpression129{{"PgClassExpression[129∈12]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
-    PgSelectSingle122 --> PgClassExpression129
-    PgClassExpression130{{"PgClassExpression[130∈12]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
-    PgSelectSingle122 --> PgClassExpression130
-    __Item160[/"__Item[160∈15]<br />ᐸ159ᐳ"\]:::itemplan
-    PgSelect159 ==> __Item160
-    PgSelectSingle161{{"PgSelectSingle[161∈15]<br />ᐸpostᐳ"}}:::plan
-    __Item160 --> PgSelectSingle161
-    __Item196[/"__Item[196∈18]<br />ᐸ218ᐳ"\]:::itemplan
-    Access218 ==> __Item196
-    PgSelectSingle197{{"PgSelectSingle[197∈18]<br />ᐸpostᐳ"}}:::plan
-    __Item196 --> PgSelectSingle197
+    PgSelectSingle83 --> PgClassExpression85
+    Lambda87{{"Lambda[87∈8]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List86 --> Lambda87
+    PgClassExpression89{{"PgClassExpression[89∈8]<br />ᐸ__person_s..._.”sekrit”ᐳ"}}:::plan
+    PgSelectSingle83 --> PgClassExpression89
+    __Item119[/"__Item[119∈11]<br />ᐸ118ᐳ"\]:::itemplan
+    PgSelect118 ==> __Item119
+    PgSelectSingle120{{"PgSelectSingle[120∈11]<br />ᐸleft_armᐳ"}}:::plan
+    __Item119 --> PgSelectSingle120
+    PgSelectSingle146 --> PgClassExpression148
+    Lambda150{{"Lambda[150∈14]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List149 --> Lambda150
+    PgClassExpression152{{"PgClassExpression[152∈14]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
+    PgSelectSingle146 --> PgClassExpression152
+    PgClassExpression153{{"PgClassExpression[153∈14]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
+    PgSelectSingle146 --> PgClassExpression153
+    PgClassExpression154{{"PgClassExpression[154∈14]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
+    PgSelectSingle146 --> PgClassExpression154
+    __Item184[/"__Item[184∈17]<br />ᐸ183ᐳ"\]:::itemplan
+    PgSelect183 ==> __Item184
+    PgSelectSingle185{{"PgSelectSingle[185∈17]<br />ᐸpostᐳ"}}:::plan
+    __Item184 --> PgSelectSingle185
+    __Item220[/"__Item[220∈20]<br />ᐸ244ᐳ"\]:::itemplan
+    Access244 ==> __Item220
+    PgSelectSingle221{{"PgSelectSingle[221∈20]<br />ᐸpostᐳ"}}:::plan
+    __Item220 --> PgSelectSingle221
     List38{{"List[38∈4]<br />ᐸ14,37ᐳ"}}:::plan
     PgClassExpression37{{"PgClassExpression[37∈4]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant14 & PgClassExpression37 --> List38
-    List99{{"List[99∈10]<br />ᐸ73,98ᐳ"}}:::plan
-    PgClassExpression98{{"PgClassExpression[98∈10]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
-    Constant73 & PgClassExpression98 --> List99
-    List164{{"List[164∈16]<br />ᐸ138,163ᐳ"}}:::plan
-    PgClassExpression163{{"PgClassExpression[163∈16]<br />ᐸ__post__.”id”ᐳ"}}:::plan
-    Constant138 & PgClassExpression163 --> List164
-    List200{{"List[200∈19]<br />ᐸ138,199ᐳ"}}:::plan
-    PgClassExpression199{{"PgClassExpression[199∈19]<br />ᐸ__post__.”id”ᐳ"}}:::plan
-    Constant138 & PgClassExpression199 --> List200
+    List123{{"List[123∈12]<br />ᐸ97,122ᐳ"}}:::plan
+    PgClassExpression122{{"PgClassExpression[122∈12]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
+    Constant97 & PgClassExpression122 --> List123
+    List188{{"List[188∈18]<br />ᐸ162,187ᐳ"}}:::plan
+    PgClassExpression187{{"PgClassExpression[187∈18]<br />ᐸ__post__.”id”ᐳ"}}:::plan
+    Constant162 & PgClassExpression187 --> List188
+    List224{{"List[224∈21]<br />ᐸ162,223ᐳ"}}:::plan
+    PgClassExpression223{{"PgClassExpression[223∈21]<br />ᐸ__post__.”id”ᐳ"}}:::plan
+    Constant162 & PgClassExpression223 --> List224
     PgSelectSingle35 --> PgClassExpression37
     Lambda39{{"Lambda[39∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List38 --> Lambda39
     PgClassExpression41{{"PgClassExpression[41∈4]<br />ᐸ__person_s..._.”sekrit”ᐳ"}}:::plan
     PgSelectSingle35 --> PgClassExpression41
-    PgSelectSingle96 --> PgClassExpression98
-    Lambda100{{"Lambda[100∈10]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List99 --> Lambda100
-    PgClassExpression102{{"PgClassExpression[102∈10]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
-    PgSelectSingle96 --> PgClassExpression102
-    PgClassExpression103{{"PgClassExpression[103∈10]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
-    PgSelectSingle96 --> PgClassExpression103
-    PgClassExpression104{{"PgClassExpression[104∈10]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
-    PgSelectSingle96 --> PgClassExpression104
-    PgSelectSingle161 --> PgClassExpression163
-    Lambda165{{"Lambda[165∈16]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List164 --> Lambda165
-    PgClassExpression167{{"PgClassExpression[167∈16]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
-    PgSelectSingle161 --> PgClassExpression167
-    PgClassExpression168{{"PgClassExpression[168∈16]<br />ᐸ__post__.”body”ᐳ"}}:::plan
-    PgSelectSingle161 --> PgClassExpression168
-    PgClassExpression169{{"PgClassExpression[169∈16]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
-    PgSelectSingle161 --> PgClassExpression169
-    PgSelectSingle197 --> PgClassExpression199
-    Lambda201{{"Lambda[201∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List200 --> Lambda201
-    PgClassExpression203{{"PgClassExpression[203∈19]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
-    PgSelectSingle197 --> PgClassExpression203
-    PgClassExpression204{{"PgClassExpression[204∈19]<br />ᐸ__post__.”body”ᐳ"}}:::plan
-    PgSelectSingle197 --> PgClassExpression204
-    PgClassExpression205{{"PgClassExpression[205∈19]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
-    PgSelectSingle197 --> PgClassExpression205
+    PgSelectSingle120 --> PgClassExpression122
+    Lambda124{{"Lambda[124∈12]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List123 --> Lambda124
+    PgClassExpression126{{"PgClassExpression[126∈12]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
+    PgSelectSingle120 --> PgClassExpression126
+    PgClassExpression127{{"PgClassExpression[127∈12]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
+    PgSelectSingle120 --> PgClassExpression127
+    PgClassExpression128{{"PgClassExpression[128∈12]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
+    PgSelectSingle120 --> PgClassExpression128
+    PgSelectSingle185 --> PgClassExpression187
+    Lambda189{{"Lambda[189∈18]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List188 --> Lambda189
+    PgClassExpression191{{"PgClassExpression[191∈18]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
+    PgSelectSingle185 --> PgClassExpression191
+    PgClassExpression192{{"PgClassExpression[192∈18]<br />ᐸ__post__.”body”ᐳ"}}:::plan
+    PgSelectSingle185 --> PgClassExpression192
+    PgClassExpression193{{"PgClassExpression[193∈18]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
+    PgSelectSingle185 --> PgClassExpression193
+    PgSelectSingle221 --> PgClassExpression223
+    Lambda225{{"Lambda[225∈21]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List224 --> Lambda225
+    PgClassExpression227{{"PgClassExpression[227∈21]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
+    PgSelectSingle221 --> PgClassExpression227
+    PgClassExpression228{{"PgClassExpression[228∈21]<br />ᐸ__post__.”body”ᐳ"}}:::plan
+    PgSelectSingle221 --> PgClassExpression228
+    PgClassExpression229{{"PgClassExpression[229∈21]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
+    PgSelectSingle221 --> PgClassExpression229
 
     %% define steps
 
     subgraph "Buckets for queries/v4/rbac.basic"
-    Bucket0("Bucket 0 (root)<br />1: <br />ᐳ: 9, 10, 14, 32, 49, 73, 93, 138, 158, 219, 220, 221, 222, 223, 11<br />2: 8, 43, 67, 106, 132, 171, 206<br />ᐳ: 12, 13, 47, 48, 71, 72, 110, 111, 136, 137, 175, 176, 210, 211"):::bucket
+    Bucket0("Bucket 0 (root)<br />1: <br />ᐳ: 9, 10, 14, 32, 49, 97, 117, 162, 182, 245, 246, 247, 248, 249, 250, 11<br />2: 8, 43, 67, 91, 130, 156, 195, 230<br />ᐳ: 12, 13, 47, 48, 71, 72, 95, 96, 134, 135, 160, 161, 199, 200, 234, 235"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value3,__Value5,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,Constant14,Connection32,PgSelect43,First47,PgSelectSingle48,Constant49,PgSelect67,First71,PgSelectSingle72,Constant73,Connection93,PgSelect106,First110,PgSelectSingle111,PgSelect132,First136,PgSelectSingle137,Constant138,Connection158,PgSelect171,First175,PgSelectSingle176,PgSelect206,First210,PgSelectSingle211,Constant219,Constant220,Constant221,Constant222,Constant223 bucket0
+    class Bucket0,__Value0,__Value3,__Value5,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,Constant14,Connection32,PgSelect43,First47,PgSelectSingle48,Constant49,PgSelect67,First71,PgSelectSingle72,PgSelect91,First95,PgSelectSingle96,Constant97,Connection117,PgSelect130,First134,PgSelectSingle135,PgSelect156,First160,PgSelectSingle161,Constant162,Connection182,PgSelect195,First199,PgSelectSingle200,PgSelect230,First234,PgSelectSingle235,Constant245,Constant246,Constant247,Constant248,Constant249,Constant250 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14<br /><br />ROOT PgSelectSingleᐸperson_secretᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression15,List16,Lambda17,PgClassExpression19 bucket1
@@ -244,57 +267,64 @@ graph TD
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 59, 14<br /><br />ROOT PgSelectSingle{5}ᐸperson_secretᐳ[59]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression61,List62,Lambda63,PgClassExpression65 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 72, 73<br /><br />ROOT PgSelectSingleᐸleft_armᐳ[72]"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 72, 49, 14<br /><br />ROOT PgSelectSingleᐸpersonᐳ[72]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression74,List75,Lambda76,PgClassExpression78,PgClassExpression79,PgClassExpression80 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 11, 93, 73<br /><br />ROOT Connectionᐸ89ᐳ[93]"):::bucket
+    class Bucket7,PgClassExpression74,List75,Lambda76,PgSelectSingle83 bucket7
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 83, 14<br /><br />ROOT PgSelectSingle{7}ᐸperson_secretᐳ[83]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgSelect94 bucket8
-    Bucket9("Bucket 9 (listItem)<br />Deps: 73<br /><br />ROOT __Item{9}ᐸ94ᐳ[95]"):::bucket
+    class Bucket8,PgClassExpression85,List86,Lambda87,PgClassExpression89 bucket8
+    Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 96, 97<br /><br />ROOT PgSelectSingleᐸleft_armᐳ[96]"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,__Item95,PgSelectSingle96 bucket9
-    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 96, 73<br /><br />ROOT PgSelectSingle{9}ᐸleft_armᐳ[96]"):::bucket
+    class Bucket9,PgClassExpression98,List99,Lambda100,PgClassExpression102,PgClassExpression103,PgClassExpression104 bucket9
+    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 11, 117, 97<br /><br />ROOT Connectionᐸ113ᐳ[117]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgClassExpression98,List99,Lambda100,PgClassExpression102,PgClassExpression103,PgClassExpression104 bucket10
-    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 111, 49, 73<br /><br />ROOT PgSelectSingleᐸpersonᐳ[111]"):::bucket
+    class Bucket10,PgSelect118 bucket10
+    Bucket11("Bucket 11 (listItem)<br />Deps: 97<br /><br />ROOT __Item{11}ᐸ118ᐳ[119]"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PgClassExpression113,List114,Lambda115,PgSelectSingle122 bucket11
-    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 122, 73<br /><br />ROOT PgSelectSingle{11}ᐸleft_armᐳ[122]"):::bucket
+    class Bucket11,__Item119,PgSelectSingle120 bucket11
+    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 120, 97<br /><br />ROOT PgSelectSingle{11}ᐸleft_armᐳ[120]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,PgClassExpression124,List125,Lambda126,PgClassExpression128,PgClassExpression129,PgClassExpression130 bucket12
-    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 137, 138<br /><br />ROOT PgSelectSingleᐸpostᐳ[137]"):::bucket
+    class Bucket12,PgClassExpression122,List123,Lambda124,PgClassExpression126,PgClassExpression127,PgClassExpression128 bucket12
+    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 135, 49, 97<br /><br />ROOT PgSelectSingleᐸpersonᐳ[135]"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgClassExpression139,List140,Lambda141,PgClassExpression143,PgClassExpression144,PgClassExpression145 bucket13
-    Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 11, 158, 138<br /><br />ROOT Connectionᐸ154ᐳ[158]"):::bucket
+    class Bucket13,PgClassExpression137,List138,Lambda139,PgSelectSingle146 bucket13
+    Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 146, 97<br /><br />ROOT PgSelectSingle{13}ᐸleft_armᐳ[146]"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PgSelect159 bucket14
-    Bucket15("Bucket 15 (listItem)<br />Deps: 138<br /><br />ROOT __Item{15}ᐸ159ᐳ[160]"):::bucket
+    class Bucket14,PgClassExpression148,List149,Lambda150,PgClassExpression152,PgClassExpression153,PgClassExpression154 bucket14
+    Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 161, 162<br /><br />ROOT PgSelectSingleᐸpostᐳ[161]"):::bucket
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,__Item160,PgSelectSingle161 bucket15
-    Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 161, 138<br /><br />ROOT PgSelectSingle{15}ᐸpostᐳ[161]"):::bucket
+    class Bucket15,PgClassExpression163,List164,Lambda165,PgClassExpression167,PgClassExpression168,PgClassExpression169 bucket15
+    Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 11, 182, 162<br /><br />ROOT Connectionᐸ178ᐳ[182]"):::bucket
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,PgClassExpression163,List164,Lambda165,PgClassExpression167,PgClassExpression168,PgClassExpression169 bucket16
-    Bucket17("Bucket 17 (nullableBoundary)<br />Deps: 176, 49, 175, 138<br /><br />ROOT PgSelectSingleᐸpersonᐳ[176]"):::bucket
+    class Bucket16,PgSelect183 bucket16
+    Bucket17("Bucket 17 (listItem)<br />Deps: 162<br /><br />ROOT __Item{17}ᐸ183ᐳ[184]"):::bucket
     classDef bucket17 stroke:#696969
-    class Bucket17,PgClassExpression178,List179,Lambda180,Connection194,Access218 bucket17
-    Bucket18("Bucket 18 (listItem)<br />Deps: 138<br /><br />ROOT __Item{18}ᐸ218ᐳ[196]"):::bucket
+    class Bucket17,__Item184,PgSelectSingle185 bucket17
+    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 185, 162<br /><br />ROOT PgSelectSingle{17}ᐸpostᐳ[185]"):::bucket
     classDef bucket18 stroke:#00bfff
-    class Bucket18,__Item196,PgSelectSingle197 bucket18
-    Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 197, 138<br /><br />ROOT PgSelectSingle{18}ᐸpostᐳ[197]"):::bucket
+    class Bucket18,PgClassExpression187,List188,Lambda189,PgClassExpression191,PgClassExpression192,PgClassExpression193 bucket18
+    Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 200, 49, 199, 162<br /><br />ROOT PgSelectSingleᐸpersonᐳ[200]"):::bucket
     classDef bucket19 stroke:#7f007f
-    class Bucket19,PgClassExpression199,List200,Lambda201,PgClassExpression203,PgClassExpression204,PgClassExpression205 bucket19
-    Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 211<br /><br />ROOT PgSelectSingleᐸreturn_table_without_grantsᐳ[211]"):::bucket
+    class Bucket19,PgClassExpression202,List203,Lambda204,Connection218,Access244 bucket19
+    Bucket20("Bucket 20 (listItem)<br />Deps: 162<br /><br />ROOT __Item{20}ᐸ244ᐳ[220]"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,PgClassExpression212,PgClassExpression213 bucket20
-    Bucket0 --> Bucket1 & Bucket2 & Bucket5 & Bucket7 & Bucket8 & Bucket11 & Bucket13 & Bucket14 & Bucket17 & Bucket20
+    class Bucket20,__Item220,PgSelectSingle221 bucket20
+    Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 221, 162<br /><br />ROOT PgSelectSingle{20}ᐸpostᐳ[221]"):::bucket
+    classDef bucket21 stroke:#0000ff
+    class Bucket21,PgClassExpression223,List224,Lambda225,PgClassExpression227,PgClassExpression228,PgClassExpression229 bucket21
+    Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 235<br /><br />ROOT PgSelectSingleᐸreturn_table_without_grantsᐳ[235]"):::bucket
+    classDef bucket22 stroke:#7fff00
+    class Bucket22,PgClassExpression236,PgClassExpression237 bucket22
+    Bucket0 --> Bucket1 & Bucket2 & Bucket5 & Bucket7 & Bucket9 & Bucket10 & Bucket13 & Bucket15 & Bucket16 & Bucket19 & Bucket22
     Bucket2 --> Bucket3
     Bucket3 --> Bucket4
     Bucket5 --> Bucket6
-    Bucket8 --> Bucket9
-    Bucket9 --> Bucket10
+    Bucket7 --> Bucket8
+    Bucket10 --> Bucket11
     Bucket11 --> Bucket12
-    Bucket14 --> Bucket15
-    Bucket15 --> Bucket16
+    Bucket13 --> Bucket14
+    Bucket16 --> Bucket17
     Bucket17 --> Bucket18
-    Bucket18 --> Bucket19
+    Bucket19 --> Bucket20
+    Bucket20 --> Bucket21
     end

--- a/postgraphile/postgraphile/__tests__/queries/v4/rbac.basic.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/rbac.basic.mermaid
@@ -14,25 +14,25 @@ graph TD
     Access10{{"Access[10∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
     Access9 & Access10 --> Object11
     PgSelect8[["PgSelect[8∈0]<br />ᐸperson_secretᐳ"]]:::plan
-    Constant245{{"Constant[245∈0]<br />ᐸ3ᐳ"}}:::plan
-    Object11 & Constant245 --> PgSelect8
+    Constant247{{"Constant[247∈0]<br />ᐸ3ᐳ"}}:::plan
+    Object11 & Constant247 --> PgSelect8
     PgSelect43[["PgSelect[43∈0]<br />ᐸpersonᐳ"]]:::plan
-    Constant246{{"Constant[246∈0]<br />ᐸ1ᐳ"}}:::plan
-    Object11 & Constant246 --> PgSelect43
-    PgSelect67[["PgSelect[67∈0]<br />ᐸpersonᐳ"]]:::plan
-    Constant247{{"Constant[247∈0]<br />ᐸ12345678ᐳ"}}:::plan
-    Object11 & Constant247 --> PgSelect67
-    PgSelect91[["PgSelect[91∈0]<br />ᐸleft_armᐳ"]]:::plan
-    Constant248{{"Constant[248∈0]<br />ᐸ42ᐳ"}}:::plan
-    Object11 & Constant248 --> PgSelect91
-    PgSelect130[["PgSelect[130∈0]<br />ᐸpersonᐳ"]]:::plan
-    Constant249{{"Constant[249∈0]<br />ᐸ2ᐳ"}}:::plan
-    Object11 & Constant249 --> PgSelect130
-    PgSelect156[["PgSelect[156∈0]<br />ᐸpostᐳ"]]:::plan
-    Constant250{{"Constant[250∈0]<br />ᐸ7ᐳ"}}:::plan
-    Object11 & Constant250 --> PgSelect156
-    PgSelect195[["PgSelect[195∈0]<br />ᐸpersonᐳ"]]:::plan
-    Object11 & Constant245 --> PgSelect195
+    Constant248{{"Constant[248∈0]<br />ᐸ1ᐳ"}}:::plan
+    Object11 & Constant248 --> PgSelect43
+    PgSelect69[["PgSelect[69∈0]<br />ᐸpersonᐳ"]]:::plan
+    Access68{{"Access[68∈0]<br />ᐸ67.1ᐳ"}}:::plan
+    Object11 & Access68 --> PgSelect69
+    PgSelect93[["PgSelect[93∈0]<br />ᐸleft_armᐳ"]]:::plan
+    Constant250{{"Constant[250∈0]<br />ᐸ42ᐳ"}}:::plan
+    Object11 & Constant250 --> PgSelect93
+    PgSelect132[["PgSelect[132∈0]<br />ᐸpersonᐳ"]]:::plan
+    Constant251{{"Constant[251∈0]<br />ᐸ2ᐳ"}}:::plan
+    Object11 & Constant251 --> PgSelect132
+    PgSelect158[["PgSelect[158∈0]<br />ᐸpostᐳ"]]:::plan
+    Constant252{{"Constant[252∈0]<br />ᐸ7ᐳ"}}:::plan
+    Object11 & Constant252 --> PgSelect158
+    PgSelect197[["PgSelect[197∈0]<br />ᐸpersonᐳ"]]:::plan
+    Object11 & Constant247 --> PgSelect197
     __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
     __Value3 --> Access9
     __Value3 --> Access10
@@ -44,98 +44,102 @@ graph TD
     PgSelect43 --> First47
     PgSelectSingle48{{"PgSelectSingle[48∈0]<br />ᐸpersonᐳ"}}:::plan
     First47 --> PgSelectSingle48
-    First71{{"First[71∈0]"}}:::plan
-    PgSelect67 --> First71
-    PgSelectSingle72{{"PgSelectSingle[72∈0]<br />ᐸpersonᐳ"}}:::plan
-    First71 --> PgSelectSingle72
-    First95{{"First[95∈0]"}}:::plan
-    PgSelect91 --> First95
-    PgSelectSingle96{{"PgSelectSingle[96∈0]<br />ᐸleft_armᐳ"}}:::plan
-    First95 --> PgSelectSingle96
-    First134{{"First[134∈0]"}}:::plan
-    PgSelect130 --> First134
-    PgSelectSingle135{{"PgSelectSingle[135∈0]<br />ᐸpersonᐳ"}}:::plan
-    First134 --> PgSelectSingle135
-    First160{{"First[160∈0]"}}:::plan
-    PgSelect156 --> First160
-    PgSelectSingle161{{"PgSelectSingle[161∈0]<br />ᐸpostᐳ"}}:::plan
-    First160 --> PgSelectSingle161
-    First199{{"First[199∈0]"}}:::plan
-    PgSelect195 --> First199
-    PgSelectSingle200{{"PgSelectSingle[200∈0]<br />ᐸpersonᐳ"}}:::plan
-    First199 --> PgSelectSingle200
-    PgSelect230[["PgSelect[230∈0]<br />ᐸreturn_table_without_grantsᐳ"]]:::plan
-    Object11 --> PgSelect230
-    First234{{"First[234∈0]"}}:::plan
-    PgSelect230 --> First234
-    PgSelectSingle235{{"PgSelectSingle[235∈0]<br />ᐸreturn_table_without_grantsᐳ"}}:::plan
-    First234 --> PgSelectSingle235
+    Lambda67{{"Lambda[67∈0]<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
+    Constant249{{"Constant[249∈0]<br />ᐸ'fa4f3e13-456c-4a9e-8c1e-37a6e3177d0b'ᐳ"}}:::plan
+    Constant249 --> Lambda67
+    Lambda67 --> Access68
+    First73{{"First[73∈0]"}}:::plan
+    PgSelect69 --> First73
+    PgSelectSingle74{{"PgSelectSingle[74∈0]<br />ᐸpersonᐳ"}}:::plan
+    First73 --> PgSelectSingle74
+    First97{{"First[97∈0]"}}:::plan
+    PgSelect93 --> First97
+    PgSelectSingle98{{"PgSelectSingle[98∈0]<br />ᐸleft_armᐳ"}}:::plan
+    First97 --> PgSelectSingle98
+    First136{{"First[136∈0]"}}:::plan
+    PgSelect132 --> First136
+    PgSelectSingle137{{"PgSelectSingle[137∈0]<br />ᐸpersonᐳ"}}:::plan
+    First136 --> PgSelectSingle137
+    First162{{"First[162∈0]"}}:::plan
+    PgSelect158 --> First162
+    PgSelectSingle163{{"PgSelectSingle[163∈0]<br />ᐸpostᐳ"}}:::plan
+    First162 --> PgSelectSingle163
+    First201{{"First[201∈0]"}}:::plan
+    PgSelect197 --> First201
+    PgSelectSingle202{{"PgSelectSingle[202∈0]<br />ᐸpersonᐳ"}}:::plan
+    First201 --> PgSelectSingle202
+    PgSelect232[["PgSelect[232∈0]<br />ᐸreturn_table_without_grantsᐳ"]]:::plan
+    Object11 --> PgSelect232
+    First236{{"First[236∈0]"}}:::plan
+    PgSelect232 --> First236
+    PgSelectSingle237{{"PgSelectSingle[237∈0]<br />ᐸreturn_table_without_grantsᐳ"}}:::plan
+    First236 --> PgSelectSingle237
     __Value0["__Value[0∈0]"]:::plan
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
     Constant14{{"Constant[14∈0]<br />ᐸ'person_secrets'ᐳ"}}:::plan
     Connection32{{"Connection[32∈0]<br />ᐸ28ᐳ"}}:::plan
     Constant49{{"Constant[49∈0]<br />ᐸ'people'ᐳ"}}:::plan
-    Constant97{{"Constant[97∈0]<br />ᐸ'left_arms'ᐳ"}}:::plan
-    Connection117{{"Connection[117∈0]<br />ᐸ113ᐳ"}}:::plan
-    Constant162{{"Constant[162∈0]<br />ᐸ'posts'ᐳ"}}:::plan
-    Connection182{{"Connection[182∈0]<br />ᐸ178ᐳ"}}:::plan
-    PgClassExpression236{{"PgClassExpression[236∈22]<br />ᐸ__return_t...rson_id_1”ᐳ"}}:::plan
-    PgSelectSingle235 --> PgClassExpression236
-    PgClassExpression237{{"PgClassExpression[237∈22]<br />ᐸ__return_t...rson_id_2”ᐳ"}}:::plan
-    PgSelectSingle235 --> PgClassExpression237
-    List203{{"List[203∈19]<br />ᐸ49,202ᐳ"}}:::plan
-    PgClassExpression202{{"PgClassExpression[202∈19]<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Constant49 & PgClassExpression202 --> List203
-    PgSelectSingle200 --> PgClassExpression202
-    Lambda204{{"Lambda[204∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List203 --> Lambda204
-    Access244{{"Access[244∈19]<br />ᐸ199.0ᐳ"}}:::plan
-    First199 --> Access244
-    Connection218{{"Connection[218∈19]<br />ᐸ214ᐳ"}}:::plan
-    PgSelect183[["PgSelect[183∈16]<br />ᐸpostᐳ"]]:::plan
-    Object11 & Connection182 --> PgSelect183
-    List164{{"List[164∈15]<br />ᐸ162,163ᐳ"}}:::plan
-    PgClassExpression163{{"PgClassExpression[163∈15]<br />ᐸ__post__.”id”ᐳ"}}:::plan
-    Constant162 & PgClassExpression163 --> List164
-    PgSelectSingle161 --> PgClassExpression163
-    Lambda165{{"Lambda[165∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List164 --> Lambda165
-    PgClassExpression167{{"PgClassExpression[167∈15]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
-    PgSelectSingle161 --> PgClassExpression167
-    PgClassExpression168{{"PgClassExpression[168∈15]<br />ᐸ__post__.”body”ᐳ"}}:::plan
-    PgSelectSingle161 --> PgClassExpression168
-    PgClassExpression169{{"PgClassExpression[169∈15]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
-    PgSelectSingle161 --> PgClassExpression169
-    List138{{"List[138∈13]<br />ᐸ49,137ᐳ"}}:::plan
-    PgClassExpression137{{"PgClassExpression[137∈13]<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Constant49 & PgClassExpression137 --> List138
-    PgSelectSingle135 --> PgClassExpression137
-    Lambda139{{"Lambda[139∈13]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List138 --> Lambda139
-    PgSelectSingle146{{"PgSelectSingle[146∈13]<br />ᐸleft_armᐳ"}}:::plan
-    PgSelectSingle135 --> PgSelectSingle146
-    PgSelect118[["PgSelect[118∈10]<br />ᐸleft_armᐳ"]]:::plan
-    Object11 & Connection117 --> PgSelect118
-    List99{{"List[99∈9]<br />ᐸ97,98ᐳ"}}:::plan
-    PgClassExpression98{{"PgClassExpression[98∈9]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
-    Constant97 & PgClassExpression98 --> List99
-    PgSelectSingle96 --> PgClassExpression98
-    Lambda100{{"Lambda[100∈9]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List99 --> Lambda100
-    PgClassExpression102{{"PgClassExpression[102∈9]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
-    PgSelectSingle96 --> PgClassExpression102
-    PgClassExpression103{{"PgClassExpression[103∈9]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
-    PgSelectSingle96 --> PgClassExpression103
-    PgClassExpression104{{"PgClassExpression[104∈9]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
-    PgSelectSingle96 --> PgClassExpression104
-    List75{{"List[75∈7]<br />ᐸ49,74ᐳ"}}:::plan
-    PgClassExpression74{{"PgClassExpression[74∈7]<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Constant49 & PgClassExpression74 --> List75
-    PgSelectSingle72 --> PgClassExpression74
-    Lambda76{{"Lambda[76∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List75 --> Lambda76
-    PgSelectSingle83{{"PgSelectSingle[83∈7]<br />ᐸperson_secretᐳ"}}:::plan
-    PgSelectSingle72 --> PgSelectSingle83
+    Constant99{{"Constant[99∈0]<br />ᐸ'left_arms'ᐳ"}}:::plan
+    Connection119{{"Connection[119∈0]<br />ᐸ115ᐳ"}}:::plan
+    Constant164{{"Constant[164∈0]<br />ᐸ'posts'ᐳ"}}:::plan
+    Connection184{{"Connection[184∈0]<br />ᐸ180ᐳ"}}:::plan
+    PgClassExpression238{{"PgClassExpression[238∈22]<br />ᐸ__return_t...rson_id_1”ᐳ"}}:::plan
+    PgSelectSingle237 --> PgClassExpression238
+    PgClassExpression239{{"PgClassExpression[239∈22]<br />ᐸ__return_t...rson_id_2”ᐳ"}}:::plan
+    PgSelectSingle237 --> PgClassExpression239
+    List205{{"List[205∈19]<br />ᐸ49,204ᐳ"}}:::plan
+    PgClassExpression204{{"PgClassExpression[204∈19]<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant49 & PgClassExpression204 --> List205
+    PgSelectSingle202 --> PgClassExpression204
+    Lambda206{{"Lambda[206∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List205 --> Lambda206
+    Access246{{"Access[246∈19]<br />ᐸ201.0ᐳ"}}:::plan
+    First201 --> Access246
+    Connection220{{"Connection[220∈19]<br />ᐸ216ᐳ"}}:::plan
+    PgSelect185[["PgSelect[185∈16]<br />ᐸpostᐳ"]]:::plan
+    Object11 & Connection184 --> PgSelect185
+    List166{{"List[166∈15]<br />ᐸ164,165ᐳ"}}:::plan
+    PgClassExpression165{{"PgClassExpression[165∈15]<br />ᐸ__post__.”id”ᐳ"}}:::plan
+    Constant164 & PgClassExpression165 --> List166
+    PgSelectSingle163 --> PgClassExpression165
+    Lambda167{{"Lambda[167∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List166 --> Lambda167
+    PgClassExpression169{{"PgClassExpression[169∈15]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
+    PgSelectSingle163 --> PgClassExpression169
+    PgClassExpression170{{"PgClassExpression[170∈15]<br />ᐸ__post__.”body”ᐳ"}}:::plan
+    PgSelectSingle163 --> PgClassExpression170
+    PgClassExpression171{{"PgClassExpression[171∈15]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
+    PgSelectSingle163 --> PgClassExpression171
+    List140{{"List[140∈13]<br />ᐸ49,139ᐳ"}}:::plan
+    PgClassExpression139{{"PgClassExpression[139∈13]<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant49 & PgClassExpression139 --> List140
+    PgSelectSingle137 --> PgClassExpression139
+    Lambda141{{"Lambda[141∈13]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List140 --> Lambda141
+    PgSelectSingle148{{"PgSelectSingle[148∈13]<br />ᐸleft_armᐳ"}}:::plan
+    PgSelectSingle137 --> PgSelectSingle148
+    PgSelect120[["PgSelect[120∈10]<br />ᐸleft_armᐳ"]]:::plan
+    Object11 & Connection119 --> PgSelect120
+    List101{{"List[101∈9]<br />ᐸ99,100ᐳ"}}:::plan
+    PgClassExpression100{{"PgClassExpression[100∈9]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
+    Constant99 & PgClassExpression100 --> List101
+    PgSelectSingle98 --> PgClassExpression100
+    Lambda102{{"Lambda[102∈9]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List101 --> Lambda102
+    PgClassExpression104{{"PgClassExpression[104∈9]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
+    PgSelectSingle98 --> PgClassExpression104
+    PgClassExpression105{{"PgClassExpression[105∈9]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
+    PgSelectSingle98 --> PgClassExpression105
+    PgClassExpression106{{"PgClassExpression[106∈9]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
+    PgSelectSingle98 --> PgClassExpression106
+    List77{{"List[77∈7]<br />ᐸ49,76ᐳ"}}:::plan
+    PgClassExpression76{{"PgClassExpression[76∈7]<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant49 & PgClassExpression76 --> List77
+    PgSelectSingle74 --> PgClassExpression76
+    Lambda78{{"Lambda[78∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List77 --> Lambda78
+    PgSelectSingle85{{"PgSelectSingle[85∈7]<br />ᐸperson_secretᐳ"}}:::plan
+    PgSelectSingle74 --> PgSelectSingle85
     List51{{"List[51∈5]<br />ᐸ49,50ᐳ"}}:::plan
     PgClassExpression50{{"PgClassExpression[50∈5]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant49 & PgClassExpression50 --> List51
@@ -157,12 +161,12 @@ graph TD
     List62{{"List[62∈6]<br />ᐸ14,61ᐳ"}}:::plan
     PgClassExpression61{{"PgClassExpression[61∈6]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant14 & PgClassExpression61 --> List62
-    List86{{"List[86∈8]<br />ᐸ14,85ᐳ"}}:::plan
-    PgClassExpression85{{"PgClassExpression[85∈8]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
-    Constant14 & PgClassExpression85 --> List86
-    List149{{"List[149∈14]<br />ᐸ97,148ᐳ"}}:::plan
-    PgClassExpression148{{"PgClassExpression[148∈14]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
-    Constant97 & PgClassExpression148 --> List149
+    List88{{"List[88∈8]<br />ᐸ14,87ᐳ"}}:::plan
+    PgClassExpression87{{"PgClassExpression[87∈8]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
+    Constant14 & PgClassExpression87 --> List88
+    List151{{"List[151∈14]<br />ᐸ99,150ᐳ"}}:::plan
+    PgClassExpression150{{"PgClassExpression[150∈14]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
+    Constant99 & PgClassExpression150 --> List151
     __Item34[/"__Item[34∈3]<br />ᐸ33ᐳ"\]:::itemplan
     PgSelect33 ==> __Item34
     PgSelectSingle35{{"PgSelectSingle[35∈3]<br />ᐸperson_secretᐳ"}}:::plan
@@ -172,83 +176,83 @@ graph TD
     List62 --> Lambda63
     PgClassExpression65{{"PgClassExpression[65∈6]<br />ᐸ__person_s..._.”sekrit”ᐳ"}}:::plan
     PgSelectSingle59 --> PgClassExpression65
-    PgSelectSingle83 --> PgClassExpression85
-    Lambda87{{"Lambda[87∈8]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List86 --> Lambda87
-    PgClassExpression89{{"PgClassExpression[89∈8]<br />ᐸ__person_s..._.”sekrit”ᐳ"}}:::plan
-    PgSelectSingle83 --> PgClassExpression89
-    __Item119[/"__Item[119∈11]<br />ᐸ118ᐳ"\]:::itemplan
-    PgSelect118 ==> __Item119
-    PgSelectSingle120{{"PgSelectSingle[120∈11]<br />ᐸleft_armᐳ"}}:::plan
-    __Item119 --> PgSelectSingle120
-    PgSelectSingle146 --> PgClassExpression148
-    Lambda150{{"Lambda[150∈14]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List149 --> Lambda150
-    PgClassExpression152{{"PgClassExpression[152∈14]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
-    PgSelectSingle146 --> PgClassExpression152
-    PgClassExpression153{{"PgClassExpression[153∈14]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
-    PgSelectSingle146 --> PgClassExpression153
-    PgClassExpression154{{"PgClassExpression[154∈14]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
-    PgSelectSingle146 --> PgClassExpression154
-    __Item184[/"__Item[184∈17]<br />ᐸ183ᐳ"\]:::itemplan
-    PgSelect183 ==> __Item184
-    PgSelectSingle185{{"PgSelectSingle[185∈17]<br />ᐸpostᐳ"}}:::plan
-    __Item184 --> PgSelectSingle185
-    __Item220[/"__Item[220∈20]<br />ᐸ244ᐳ"\]:::itemplan
-    Access244 ==> __Item220
-    PgSelectSingle221{{"PgSelectSingle[221∈20]<br />ᐸpostᐳ"}}:::plan
-    __Item220 --> PgSelectSingle221
+    PgSelectSingle85 --> PgClassExpression87
+    Lambda89{{"Lambda[89∈8]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List88 --> Lambda89
+    PgClassExpression91{{"PgClassExpression[91∈8]<br />ᐸ__person_s..._.”sekrit”ᐳ"}}:::plan
+    PgSelectSingle85 --> PgClassExpression91
+    __Item121[/"__Item[121∈11]<br />ᐸ120ᐳ"\]:::itemplan
+    PgSelect120 ==> __Item121
+    PgSelectSingle122{{"PgSelectSingle[122∈11]<br />ᐸleft_armᐳ"}}:::plan
+    __Item121 --> PgSelectSingle122
+    PgSelectSingle148 --> PgClassExpression150
+    Lambda152{{"Lambda[152∈14]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List151 --> Lambda152
+    PgClassExpression154{{"PgClassExpression[154∈14]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
+    PgSelectSingle148 --> PgClassExpression154
+    PgClassExpression155{{"PgClassExpression[155∈14]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
+    PgSelectSingle148 --> PgClassExpression155
+    PgClassExpression156{{"PgClassExpression[156∈14]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
+    PgSelectSingle148 --> PgClassExpression156
+    __Item186[/"__Item[186∈17]<br />ᐸ185ᐳ"\]:::itemplan
+    PgSelect185 ==> __Item186
+    PgSelectSingle187{{"PgSelectSingle[187∈17]<br />ᐸpostᐳ"}}:::plan
+    __Item186 --> PgSelectSingle187
+    __Item222[/"__Item[222∈20]<br />ᐸ246ᐳ"\]:::itemplan
+    Access246 ==> __Item222
+    PgSelectSingle223{{"PgSelectSingle[223∈20]<br />ᐸpostᐳ"}}:::plan
+    __Item222 --> PgSelectSingle223
     List38{{"List[38∈4]<br />ᐸ14,37ᐳ"}}:::plan
     PgClassExpression37{{"PgClassExpression[37∈4]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant14 & PgClassExpression37 --> List38
-    List123{{"List[123∈12]<br />ᐸ97,122ᐳ"}}:::plan
-    PgClassExpression122{{"PgClassExpression[122∈12]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
-    Constant97 & PgClassExpression122 --> List123
-    List188{{"List[188∈18]<br />ᐸ162,187ᐳ"}}:::plan
-    PgClassExpression187{{"PgClassExpression[187∈18]<br />ᐸ__post__.”id”ᐳ"}}:::plan
-    Constant162 & PgClassExpression187 --> List188
-    List224{{"List[224∈21]<br />ᐸ162,223ᐳ"}}:::plan
-    PgClassExpression223{{"PgClassExpression[223∈21]<br />ᐸ__post__.”id”ᐳ"}}:::plan
-    Constant162 & PgClassExpression223 --> List224
+    List125{{"List[125∈12]<br />ᐸ99,124ᐳ"}}:::plan
+    PgClassExpression124{{"PgClassExpression[124∈12]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
+    Constant99 & PgClassExpression124 --> List125
+    List190{{"List[190∈18]<br />ᐸ164,189ᐳ"}}:::plan
+    PgClassExpression189{{"PgClassExpression[189∈18]<br />ᐸ__post__.”id”ᐳ"}}:::plan
+    Constant164 & PgClassExpression189 --> List190
+    List226{{"List[226∈21]<br />ᐸ164,225ᐳ"}}:::plan
+    PgClassExpression225{{"PgClassExpression[225∈21]<br />ᐸ__post__.”id”ᐳ"}}:::plan
+    Constant164 & PgClassExpression225 --> List226
     PgSelectSingle35 --> PgClassExpression37
     Lambda39{{"Lambda[39∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List38 --> Lambda39
     PgClassExpression41{{"PgClassExpression[41∈4]<br />ᐸ__person_s..._.”sekrit”ᐳ"}}:::plan
     PgSelectSingle35 --> PgClassExpression41
-    PgSelectSingle120 --> PgClassExpression122
-    Lambda124{{"Lambda[124∈12]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List123 --> Lambda124
-    PgClassExpression126{{"PgClassExpression[126∈12]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
-    PgSelectSingle120 --> PgClassExpression126
-    PgClassExpression127{{"PgClassExpression[127∈12]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
-    PgSelectSingle120 --> PgClassExpression127
-    PgClassExpression128{{"PgClassExpression[128∈12]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
-    PgSelectSingle120 --> PgClassExpression128
-    PgSelectSingle185 --> PgClassExpression187
-    Lambda189{{"Lambda[189∈18]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List188 --> Lambda189
-    PgClassExpression191{{"PgClassExpression[191∈18]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
-    PgSelectSingle185 --> PgClassExpression191
-    PgClassExpression192{{"PgClassExpression[192∈18]<br />ᐸ__post__.”body”ᐳ"}}:::plan
-    PgSelectSingle185 --> PgClassExpression192
-    PgClassExpression193{{"PgClassExpression[193∈18]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
-    PgSelectSingle185 --> PgClassExpression193
-    PgSelectSingle221 --> PgClassExpression223
-    Lambda225{{"Lambda[225∈21]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List224 --> Lambda225
-    PgClassExpression227{{"PgClassExpression[227∈21]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
-    PgSelectSingle221 --> PgClassExpression227
-    PgClassExpression228{{"PgClassExpression[228∈21]<br />ᐸ__post__.”body”ᐳ"}}:::plan
-    PgSelectSingle221 --> PgClassExpression228
-    PgClassExpression229{{"PgClassExpression[229∈21]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
-    PgSelectSingle221 --> PgClassExpression229
+    PgSelectSingle122 --> PgClassExpression124
+    Lambda126{{"Lambda[126∈12]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List125 --> Lambda126
+    PgClassExpression128{{"PgClassExpression[128∈12]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
+    PgSelectSingle122 --> PgClassExpression128
+    PgClassExpression129{{"PgClassExpression[129∈12]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
+    PgSelectSingle122 --> PgClassExpression129
+    PgClassExpression130{{"PgClassExpression[130∈12]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
+    PgSelectSingle122 --> PgClassExpression130
+    PgSelectSingle187 --> PgClassExpression189
+    Lambda191{{"Lambda[191∈18]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List190 --> Lambda191
+    PgClassExpression193{{"PgClassExpression[193∈18]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
+    PgSelectSingle187 --> PgClassExpression193
+    PgClassExpression194{{"PgClassExpression[194∈18]<br />ᐸ__post__.”body”ᐳ"}}:::plan
+    PgSelectSingle187 --> PgClassExpression194
+    PgClassExpression195{{"PgClassExpression[195∈18]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
+    PgSelectSingle187 --> PgClassExpression195
+    PgSelectSingle223 --> PgClassExpression225
+    Lambda227{{"Lambda[227∈21]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List226 --> Lambda227
+    PgClassExpression229{{"PgClassExpression[229∈21]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
+    PgSelectSingle223 --> PgClassExpression229
+    PgClassExpression230{{"PgClassExpression[230∈21]<br />ᐸ__post__.”body”ᐳ"}}:::plan
+    PgSelectSingle223 --> PgClassExpression230
+    PgClassExpression231{{"PgClassExpression[231∈21]<br />ᐸ__post__.”author_id”ᐳ"}}:::plan
+    PgSelectSingle223 --> PgClassExpression231
 
     %% define steps
 
     subgraph "Buckets for queries/v4/rbac.basic"
-    Bucket0("Bucket 0 (root)<br />1: <br />ᐳ: 9, 10, 14, 32, 49, 97, 117, 162, 182, 245, 246, 247, 248, 249, 250, 11<br />2: 8, 43, 67, 91, 130, 156, 195, 230<br />ᐳ: 12, 13, 47, 48, 71, 72, 95, 96, 134, 135, 160, 161, 199, 200, 234, 235"):::bucket
+    Bucket0("Bucket 0 (root)<br />1: <br />ᐳ: 9, 10, 14, 32, 49, 99, 119, 164, 184, 247, 248, 249, 250, 251, 252, 11, 67, 68<br />2: 8, 43, 69, 93, 132, 158, 197, 232<br />ᐳ: 12, 13, 47, 48, 73, 74, 97, 98, 136, 137, 162, 163, 201, 202, 236, 237"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value3,__Value5,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,Constant14,Connection32,PgSelect43,First47,PgSelectSingle48,Constant49,PgSelect67,First71,PgSelectSingle72,PgSelect91,First95,PgSelectSingle96,Constant97,Connection117,PgSelect130,First134,PgSelectSingle135,PgSelect156,First160,PgSelectSingle161,Constant162,Connection182,PgSelect195,First199,PgSelectSingle200,PgSelect230,First234,PgSelectSingle235,Constant245,Constant246,Constant247,Constant248,Constant249,Constant250 bucket0
+    class Bucket0,__Value0,__Value3,__Value5,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,Constant14,Connection32,PgSelect43,First47,PgSelectSingle48,Constant49,Lambda67,Access68,PgSelect69,First73,PgSelectSingle74,PgSelect93,First97,PgSelectSingle98,Constant99,Connection119,PgSelect132,First136,PgSelectSingle137,PgSelect158,First162,PgSelectSingle163,Constant164,Connection184,PgSelect197,First201,PgSelectSingle202,PgSelect232,First236,PgSelectSingle237,Constant247,Constant248,Constant249,Constant250,Constant251,Constant252 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13, 14<br /><br />ROOT PgSelectSingleᐸperson_secretᐳ[13]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgClassExpression15,List16,Lambda17,PgClassExpression19 bucket1
@@ -267,54 +271,54 @@ graph TD
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 59, 14<br /><br />ROOT PgSelectSingle{5}ᐸperson_secretᐳ[59]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression61,List62,Lambda63,PgClassExpression65 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 72, 49, 14<br /><br />ROOT PgSelectSingleᐸpersonᐳ[72]"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 74, 49, 14<br /><br />ROOT PgSelectSingleᐸpersonᐳ[74]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgClassExpression74,List75,Lambda76,PgSelectSingle83 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 83, 14<br /><br />ROOT PgSelectSingle{7}ᐸperson_secretᐳ[83]"):::bucket
+    class Bucket7,PgClassExpression76,List77,Lambda78,PgSelectSingle85 bucket7
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 85, 14<br /><br />ROOT PgSelectSingle{7}ᐸperson_secretᐳ[85]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgClassExpression85,List86,Lambda87,PgClassExpression89 bucket8
-    Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 96, 97<br /><br />ROOT PgSelectSingleᐸleft_armᐳ[96]"):::bucket
+    class Bucket8,PgClassExpression87,List88,Lambda89,PgClassExpression91 bucket8
+    Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 98, 99<br /><br />ROOT PgSelectSingleᐸleft_armᐳ[98]"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,PgClassExpression98,List99,Lambda100,PgClassExpression102,PgClassExpression103,PgClassExpression104 bucket9
-    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 11, 117, 97<br /><br />ROOT Connectionᐸ113ᐳ[117]"):::bucket
+    class Bucket9,PgClassExpression100,List101,Lambda102,PgClassExpression104,PgClassExpression105,PgClassExpression106 bucket9
+    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 11, 119, 99<br /><br />ROOT Connectionᐸ115ᐳ[119]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgSelect118 bucket10
-    Bucket11("Bucket 11 (listItem)<br />Deps: 97<br /><br />ROOT __Item{11}ᐸ118ᐳ[119]"):::bucket
+    class Bucket10,PgSelect120 bucket10
+    Bucket11("Bucket 11 (listItem)<br />Deps: 99<br /><br />ROOT __Item{11}ᐸ120ᐳ[121]"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,__Item119,PgSelectSingle120 bucket11
-    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 120, 97<br /><br />ROOT PgSelectSingle{11}ᐸleft_armᐳ[120]"):::bucket
+    class Bucket11,__Item121,PgSelectSingle122 bucket11
+    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 122, 99<br /><br />ROOT PgSelectSingle{11}ᐸleft_armᐳ[122]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,PgClassExpression122,List123,Lambda124,PgClassExpression126,PgClassExpression127,PgClassExpression128 bucket12
-    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 135, 49, 97<br /><br />ROOT PgSelectSingleᐸpersonᐳ[135]"):::bucket
+    class Bucket12,PgClassExpression124,List125,Lambda126,PgClassExpression128,PgClassExpression129,PgClassExpression130 bucket12
+    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 137, 49, 99<br /><br />ROOT PgSelectSingleᐸpersonᐳ[137]"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgClassExpression137,List138,Lambda139,PgSelectSingle146 bucket13
-    Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 146, 97<br /><br />ROOT PgSelectSingle{13}ᐸleft_armᐳ[146]"):::bucket
+    class Bucket13,PgClassExpression139,List140,Lambda141,PgSelectSingle148 bucket13
+    Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 148, 99<br /><br />ROOT PgSelectSingle{13}ᐸleft_armᐳ[148]"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,PgClassExpression148,List149,Lambda150,PgClassExpression152,PgClassExpression153,PgClassExpression154 bucket14
-    Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 161, 162<br /><br />ROOT PgSelectSingleᐸpostᐳ[161]"):::bucket
+    class Bucket14,PgClassExpression150,List151,Lambda152,PgClassExpression154,PgClassExpression155,PgClassExpression156 bucket14
+    Bucket15("Bucket 15 (nullableBoundary)<br />Deps: 163, 164<br /><br />ROOT PgSelectSingleᐸpostᐳ[163]"):::bucket
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,PgClassExpression163,List164,Lambda165,PgClassExpression167,PgClassExpression168,PgClassExpression169 bucket15
-    Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 11, 182, 162<br /><br />ROOT Connectionᐸ178ᐳ[182]"):::bucket
+    class Bucket15,PgClassExpression165,List166,Lambda167,PgClassExpression169,PgClassExpression170,PgClassExpression171 bucket15
+    Bucket16("Bucket 16 (nullableBoundary)<br />Deps: 11, 184, 164<br /><br />ROOT Connectionᐸ180ᐳ[184]"):::bucket
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,PgSelect183 bucket16
-    Bucket17("Bucket 17 (listItem)<br />Deps: 162<br /><br />ROOT __Item{17}ᐸ183ᐳ[184]"):::bucket
+    class Bucket16,PgSelect185 bucket16
+    Bucket17("Bucket 17 (listItem)<br />Deps: 164<br /><br />ROOT __Item{17}ᐸ185ᐳ[186]"):::bucket
     classDef bucket17 stroke:#696969
-    class Bucket17,__Item184,PgSelectSingle185 bucket17
-    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 185, 162<br /><br />ROOT PgSelectSingle{17}ᐸpostᐳ[185]"):::bucket
+    class Bucket17,__Item186,PgSelectSingle187 bucket17
+    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 187, 164<br /><br />ROOT PgSelectSingle{17}ᐸpostᐳ[187]"):::bucket
     classDef bucket18 stroke:#00bfff
-    class Bucket18,PgClassExpression187,List188,Lambda189,PgClassExpression191,PgClassExpression192,PgClassExpression193 bucket18
-    Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 200, 49, 199, 162<br /><br />ROOT PgSelectSingleᐸpersonᐳ[200]"):::bucket
+    class Bucket18,PgClassExpression189,List190,Lambda191,PgClassExpression193,PgClassExpression194,PgClassExpression195 bucket18
+    Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 202, 49, 201, 164<br /><br />ROOT PgSelectSingleᐸpersonᐳ[202]"):::bucket
     classDef bucket19 stroke:#7f007f
-    class Bucket19,PgClassExpression202,List203,Lambda204,Connection218,Access244 bucket19
-    Bucket20("Bucket 20 (listItem)<br />Deps: 162<br /><br />ROOT __Item{20}ᐸ244ᐳ[220]"):::bucket
+    class Bucket19,PgClassExpression204,List205,Lambda206,Connection220,Access246 bucket19
+    Bucket20("Bucket 20 (listItem)<br />Deps: 164<br /><br />ROOT __Item{20}ᐸ246ᐳ[222]"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,__Item220,PgSelectSingle221 bucket20
-    Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 221, 162<br /><br />ROOT PgSelectSingle{20}ᐸpostᐳ[221]"):::bucket
+    class Bucket20,__Item222,PgSelectSingle223 bucket20
+    Bucket21("Bucket 21 (nullableBoundary)<br />Deps: 223, 164<br /><br />ROOT PgSelectSingle{20}ᐸpostᐳ[223]"):::bucket
     classDef bucket21 stroke:#0000ff
-    class Bucket21,PgClassExpression223,List224,Lambda225,PgClassExpression227,PgClassExpression228,PgClassExpression229 bucket21
-    Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 235<br /><br />ROOT PgSelectSingleᐸreturn_table_without_grantsᐳ[235]"):::bucket
+    class Bucket21,PgClassExpression225,List226,Lambda227,PgClassExpression229,PgClassExpression230,PgClassExpression231 bucket21
+    Bucket22("Bucket 22 (nullableBoundary)<br />Deps: 237<br /><br />ROOT PgSelectSingleᐸreturn_table_without_grantsᐳ[237]"):::bucket
     classDef bucket22 stroke:#7fff00
-    class Bucket22,PgClassExpression236,PgClassExpression237 bucket22
+    class Bucket22,PgClassExpression238,PgClassExpression239 bucket22
     Bucket0 --> Bucket1 & Bucket2 & Bucket5 & Bucket7 & Bucket9 & Bucket10 & Bucket13 & Bucket15 & Bucket16 & Bucket19 & Bucket22
     Bucket2 --> Bucket3
     Bucket3 --> Bucket4

--- a/postgraphile/postgraphile/__tests__/queries/v4/rbac.basic.sql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/rbac.basic.sql
@@ -43,6 +43,28 @@ begin; /*fake*/
 
 select set_config(el->>0, el->>1, true) from json_array_elements($1::json) el
 
+select __person_result__.*
+from (select 0 as idx, $1::"int4" as "id0") as __person_identifiers__,
+lateral (
+  select
+    __person_secret__."person_id"::text as "0",
+    __person_secret__."sekrit" as "1",
+    __person__."id"::text as "2",
+    __person_identifiers__.idx as "3"
+  from "c"."person" as __person__
+  left outer join "c"."person_secret" as __person_secret__
+  on (__person__."id"::"int4" = __person_secret__."person_id")
+  where (
+    __person__."id" = __person_identifiers__."id0"
+  )
+) as __person_result__;
+
+commit; /*fake*/
+
+begin; /*fake*/
+
+select set_config(el->>0, el->>1, true) from json_array_elements($1::json) el
+
 select __left_arm_result__.*
 from (select 0 as idx, $1::"int4" as "id0") as __left_arm_identifiers__,
 lateral (

--- a/postgraphile/postgraphile/__tests__/queries/v4/rbac.basic.test.graphql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/rbac.basic.test.graphql
@@ -6,7 +6,7 @@ query {
   personSecretByPersonId(personId: 3) { nodeId personId secret }
   allPersonSecrets { nodes { nodeId personId secret } }
   personForSecret: personById(id: 1) { nodeId personSecretByPersonId { nodeId personId secret } }
-  nxPerson: personById(id: 12345678) { nodeId personSecretByPersonId { nodeId personId secret } }
+  nxPerson: person(nodeId: "fa4f3e13-456c-4a9e-8c1e-37a6e3177d0b") { nodeId personSecretByPersonId { nodeId personId secret } }
 
   leftArmById(id: 42) { nodeId id personId lengthInMetres mood }
   allLeftArms { nodes { nodeId id personId lengthInMetres mood } }

--- a/postgraphile/postgraphile/__tests__/queries/v4/rbac.basic.test.graphql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/rbac.basic.test.graphql
@@ -6,6 +6,7 @@ query {
   personSecretByPersonId(personId: 3) { nodeId personId secret }
   allPersonSecrets { nodes { nodeId personId secret } }
   personForSecret: personById(id: 1) { nodeId personSecretByPersonId { nodeId personId secret } }
+  nxPerson: personById(id: 12345678) { nodeId personSecretByPersonId { nodeId personId secret } }
 
   leftArmById(id: 42) { nodeId id personId lengthInMetres mood }
   allLeftArms { nodes { nodeId id personId lengthInMetres mood } }


### PR DESCRIPTION
`access($foo, ['a', 'b'])` would throw if $foo represented `{a: null}`. Now it returns undefined instead. (This was always the case with the unoptimized version, but the eval'd version was simplified.)