### PR TITLE
Add GrafastOptions to GraphileConfig namespace

### DIFF
--- a/grafast/grafast/src/interfaces.ts
+++ b/grafast/grafast/src/interfaces.ts
@@ -70,32 +70,6 @@ export interface GrafastTimeouts {
   // synchronous it's typically so fast that no timeout is required.
 }
 
-export interface GrafastOptions {
-  /**
-   * An object to merge into the GraphQL context. Alternatively, pass an
-   * (optionally asynchronous) function that returns an object to merge into
-   * the GraphQL context.
-   */
-  context?:
-    | Partial<Grafast.Context>
-    | ((
-        ctx: Partial<Grafast.RequestContext>,
-        args: Grafast.ExecutionArgs,
-      ) => PromiseOrValue<Partial<Grafast.Context>>);
-
-  /**
-   * A list of 'explain' types that should be included in `extensions.explain`.
-   *
-   * - `mermaid-js` will cause the mermaid plan to be included
-   * - other values are dependent on the plugins in play
-   *
-   * If set to `true` then all possible explain types will be exposed.
-   */
-  explain?: boolean | string[];
-
-  timeouts?: GrafastTimeouts;
-}
-
 export const $$queryCache = Symbol("queryCache");
 
 /**
@@ -245,12 +219,37 @@ declare global {
     }
   }
   namespace GraphileConfig {
+    interface GrafastOptions {
+      /**
+       * An object to merge into the GraphQL context. Alternatively, pass an
+       * (optionally asynchronous) function that returns an object to merge into
+       * the GraphQL context.
+       */
+      context?:
+        | Partial<Grafast.Context>
+        | ((
+            ctx: Partial<Grafast.RequestContext>,
+            args: Grafast.ExecutionArgs,
+          ) => PromiseOrValue<Partial<Grafast.Context>>);
+
+      /**
+       * A list of 'explain' types that should be included in `extensions.explain`.
+       *
+       * - `mermaid-js` will cause the mermaid plan to be included
+       * - other values are dependent on the plugins in play
+       *
+       * If set to `true` then all possible explain types will be exposed.
+       */
+      explain?: boolean | string[];
+
+      timeouts?: GrafastTimeouts;
+    }
     interface Preset {
       /**
        * Options that control how `grafast` should execute your GraphQL
        * operations.
        */
-      grafast?: GrafastOptions;
+      grafast?: GraphileConfig.GrafastOptions;
     }
     interface GrafastHooks {
       args: PluginHook<

--- a/postgraphile/website/postgraphile/config.mdx
+++ b/postgraphile/website/postgraphile/config.mdx
@@ -500,7 +500,7 @@ to determine the options that they offer.
 
 ### `grafast` options
 
-_(TypeScript type: `import type { GrafastOptions } from "grafast"`)_
+_(TypeScript type: `GraphileConfig.GrafastOptions`)_
 
 - `explain` - a list of 'explain' types that should be exposed to clients via
   `extensions.explain` (`mermaid-js` for the operation plan, `sql` for the


### PR DESCRIPTION
Wasn't exported previously. This is consistent with GraphileConfig.GrafservOptions now