### PR TITLE
Improve error message for duplicate resource name

### DIFF
--- a/grafast/dataplan-pg/src/datasource.ts
+++ b/grafast/dataplan-pg/src/datasource.ts
@@ -1336,7 +1336,10 @@ export function makeRegistryBuilder(): PgRegistryBuilder<{}, {}, {}> {
               resource.name
             }' (first represented ${printResourceFrom(
               existing,
-            )}, second represents ${printResourceFrom(resource)})`,
+            )}, second represents ${printResourceFrom(
+              resource,
+            )}):\n  Details: ${chalk.bold.blue
+              .underline`https://err.red/p2rc`}`,
           );
         }
         return builder;

--- a/grafast/dataplan-pg/src/datasource.ts
+++ b/grafast/dataplan-pg/src/datasource.ts
@@ -1313,11 +1313,30 @@ export function makeRegistryBuilder(): PgRegistryBuilder<{}, {}, {}> {
     },
 
     addResource(resource) {
-      const existing = registryConfig.pgResources[resource.name];
+      const existing = registryConfig.pgResources[resource.name] as
+        | PgResourceOptions
+        | undefined;
       if (existing) {
         if (existing !== resource) {
+          function printResourceFrom(resource: PgResourceOptions): string {
+            if (typeof resource.from === "function") {
+              return `function accepting ${
+                resource.parameters?.length
+              } parameters and returning SQL type '${
+                sql.compile(resource.codec.sqlType).text
+              }'`;
+            } else {
+              return `table/view/etc called '${
+                sql.compile(resource.from).text
+              }'`;
+            }
+          }
           throw new Error(
-            `Attempted to add a second resource named '${resource.name}' (existing: ${existing}, new: ${resource})`,
+            `Attempted to add a second resource named '${
+              resource.name
+            }' (first represented ${printResourceFrom(
+              existing,
+            )}, second represents ${printResourceFrom(resource)})`,
           );
         }
         return builder;

--- a/grafast/dataplan-pg/src/datasource.ts
+++ b/grafast/dataplan-pg/src/datasource.ts
@@ -1318,19 +1318,6 @@ export function makeRegistryBuilder(): PgRegistryBuilder<{}, {}, {}> {
         | undefined;
       if (existing) {
         if (existing !== resource) {
-          function printResourceFrom(resource: PgResourceOptions): string {
-            if (typeof resource.from === "function") {
-              return `function accepting ${
-                resource.parameters?.length
-              } parameters and returning SQL type '${
-                sql.compile(resource.codec.sqlType).text
-              }'`;
-            } else {
-              return `table/view/etc called '${
-                sql.compile(resource.from).text
-              }'`;
-            }
-          }
           throw new Error(
             `Attempted to add a second resource named '${
               resource.name
@@ -1393,3 +1380,15 @@ export function makePgResourceOptions<
 }
 
 exportAs("@dataplan/pg", makePgResourceOptions, "makePgResourceOptions");
+
+function printResourceFrom(resource: PgResourceOptions): string {
+  if (typeof resource.from === "function") {
+    return `function accepting ${
+      resource.parameters?.length
+    } parameters and returning SQL type '${
+      sql.compile(resource.codec.sqlType).text
+    }'`;
+  } else {
+    return `table/view/etc called '${sql.compile(resource.from).text}'`;
+  }
+}

--- a/grafast/website/grafast/step-library/dataplan-pg/registry/resources.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/registry/resources.md
@@ -97,10 +97,26 @@ const forumsResourceOptions = makePgResourceOptions({
 Once a resource has been built (from the result of a call to `makeRegistry()` -
 see [registry](./index.md)), you can use the various helper methods:
 
-- `get(spec)` - call this from a plan resolver; gets a step representing a single row from this table-like resource matching the given spec
-- `find(spec)` - call this from a plan resolver; gets a step representing a list of rows from this table-like resource matching the given spec
-- `execute(args)` - call this from a plan resolver; gets a step representing the result of calling the database function this resource represents, passing the given arguments
-- `getRelations()` - gets the map of relation definitions available on this resource (by looking up its codec in the registry)
-- `getRelation(name)` - gets the named relation definition
+### `resource.get(spec)`
 
-You can also use resources as parameters to various of the @dataplan/pg steps.
+Call this from a plan resolver; gets a step representing a single row from this
+table-like resource matching the given spec
+
+### `resource.find(spec)`
+
+Call this from a plan resolver; gets a step representing a list of rows from
+this table-like resource matching the given spec
+
+### `resource.execute(args)`
+
+Call this from a plan resolver; gets a step representing the result of calling
+the database function this resource represents, passing the given arguments
+
+### `resource.getRelations()`
+
+Gets the map of relation definitions available on this resource (by looking up
+its codec in the registry)
+
+### `resource.getRelation(name)`
+
+Gets the named relation definition

--- a/postgraphile/website/postgraphile/errors/2rc.md
+++ b/postgraphile/website/postgraphile/errors/2rc.md
@@ -1,0 +1,33 @@
+---
+title: Two resources conflicted
+---
+
+You're probably here because you just received an error like:
+
+`Error: Attempted to add a second resource named 'foo' (first represented function accepting 0 parameters and returning SQL type '"bool"', second represents table/view/etc called '"public"."foo"')
+  Details: https://err.red/p2rc`
+
+This happens when PostGraphile is building the
+[resources](../registry.md#resources) for your schema, and the inflection rules
+tell it to assign them both the same name
+
+Remember: a resource represents somewhere that you can pull data from in your
+database, for example a table or a function.
+
+This might happen if:
+
+- you have a table and a function with the same (or similar) names
+- you have tables with the same (or similar) names in multiple schemas
+- you have "interesting" inflection rules :wink:
+
+The error itself should hopefully hint at which entities are clashing. To resolve the issue, you should either:
+
+1. rename one of the database entities, or
+2. use a [smart tag](../smart-tags.md) to assign a different name to one of the resources, or
+3. use a custom inflector to give one of the entities a different name.
+
+Generally the smart tag is the recommended approach for one-off issues, however
+if this is a systemic issue (for example you use a lot of schemas, and the
+schemas frequently have a lot of table names in common) then it may be wise to
+change your inflectors to make the resource names more unique - for example
+factoring the schema name into the name of the resource.

--- a/postgraphile/website/postgraphile/errors/index.md
+++ b/postgraphile/website/postgraphile/errors/index.md
@@ -1,0 +1,5 @@
+# Errors
+
+Here you'll find details of some of the errors you may come across when you use
+PostGraphile. These pages are not meant to be read until you hit such an error,
+so you may skip over them.

--- a/postgraphile/website/postgraphile/registry.md
+++ b/postgraphile/website/postgraphile/registry.md
@@ -1,0 +1,100 @@
+---
+title: Registry
+---
+
+As you know: PostGraphile builds a GraphQL schema for you by introspecting your
+database. What you may not know is that it does this through multiple phases
+using the [Graphile Build](https://build.graphile.org/graphile-build/) library.
+In the `gather` phase, PostGraphile introspects your database, and builds up a
+"registry" of all of the "codecs", "resources" and "relations" that it finds.
+Then during the `schema` phase, it inspects this registry and uses it to decide
+what your GraphQL schema should contain.
+
+When you're just getting started with PostGraphile, it's not very important to
+understand the registry, you can get away with these basic concepts to help you
+to understand error messages:
+
+- A `codec` represents a database type (a scalar, composite, list, domain or range type)
+- A `resource` represents something in the database from which you can pull data (a table, view, materialized view or function)
+- A `relation` is a uni-directional link from a codec (e.g. a table _type_) to a resource (e.g. a table itself)
+
+However, once you want to start writing your own plans, for example via
+[`makeExtendSchemaPlugin`](./make-extend-schema-plugin.md), understanding the
+registry becomes more important.
+
+## Codecs
+
+A "codec" describes a type in your PostgreSQL database. There are built-in
+codecs for the basic scalars:
+
+```ts
+import { TYPES } from "postgraphile/@dataplan/pg";
+
+const { int, bool, text /* ... */ } = TYPES;
+```
+
+PostGraphile will automatically generate codecs for all of the types in your
+database, whether they are scalar, composite (including the underlying type
+that each of your tables/views/etc have), list, domain, or range types.
+
+PostGraphile automatically names these types after their name in the database
+via an inflector. For example, composite types use the `classCodecName`
+inflector.
+
+You can read more about codecs (including how to make your own, and what the
+built-in scalar codecs are) in the `@dataplan/pg` documentation:
+https://grafast.org/grafast/step-library/dataplan-pg/registry/codecs
+
+## Resources
+
+A "resource" represents something that you can pull data from in your database.
+Most commonly this is a table, but it also includes views, materialized views
+and functions. You can even build resources for custom SQL expressions should
+you wish.
+
+PostGraphile automatically build resources for you based on all your tables,
+views, materialized views and functions.
+
+There are two main classes of resources. "Table-like" resources don't accept
+any parameters, you can get resources from them directly using
+[`resource.find(spec)`](https://grafast.org/grafast/step-library/dataplan-pg/registry/resources#resourcefindspec)
+or
+[`resource.get(spec)`](https://grafast.org/grafast/step-library/dataplan-pg/registry/resources#resourcegetspec).
+"Function-like" resources require a list of parameters (even an empty list),
+and for these you would use
+[`resource.execute(args)`](https://grafast.org/grafast/step-library/dataplan-pg/registry/resources#resourcefindspec).
+
+You can read more about resources in the `@dataplan/pg` documentation:
+https://grafast.org/grafast/step-library/dataplan-pg/registry/resources
+
+## Relations
+
+A "relation" is a uni-directional (one way) relationship from a codec (i.e.
+type) to a table-like resource (i.e. table). Assuming you have some data for
+the given codec (whether you got that data from a table, function, or even read
+it from a file), a relation describes how to get from that to the related
+records (or record) in the given resource.
+
+In general, foreign key constraints will register _two_ relations, one for the
+referring table (the table on which the foreign key is defined) to the
+referenced table (this is the "forward" relation, and is always unique) and one
+from the referenced table back to the referring table (this is the "backward"
+or "referencee" relation, and may or may not be unique depending on the unique
+constraints on the referring table).
+
+You can read more about relations in the `@dataplan/pg` documentation:
+https://grafast.org/grafast/step-library/dataplan-pg/registry/relations
+
+## Registry
+
+The registry is the container for codecs, resources, and relations. When you're
+writing a plugin, if you have a reference to the `build` object then you can
+access the registry via `build.input.pgRegistry`. It contains the properties
+`pgCodecs`, `pgResources` and `pgRelations`. If you had a `users` table then,
+depending on the inflectors you're using, it's codec might be
+`build.input.pgRegistry.pgCodecs.users`, its resource
+`build.input.pgRegistry.pgResources.users` and its relations a keyed object
+(hash/map/record) stored at `build.input.pgRegistry.pgRelations.users`.
+
+You can read more about the registry in the `@dataplan/pg` documentation:
+https://grafast.org/grafast/step-library/dataplan-pg/registry/

--- a/postgraphile/website/sidebars.js
+++ b/postgraphile/website/sidebars.js
@@ -41,8 +41,9 @@ const sidebars = {
       defaultStyle: false,
     },
     "quick-start-guide",
-    "namespaces",
+    "registry",
     "inflection",
+    "namespaces",
     {
       type: "category",
       label: "Tables",


### PR DESCRIPTION
Fixes #447

I've just bought the new domain `err.red` (errored) to use as short links in Graphile's projects. I've set `https://err.red/p*` to redirect to `https://postgraphile.org/postgraphile/next/errors/$1`, so now we can add error pages to the PostGraphile documentation and then link them from the error messages themselves. I wanted to do this to give more detail on the `Attempted to add a second resource named ...` error that @dmfay reported... But in writing the documentation for this error, I realised that we didn't even tell people what a "resource" was in the PostGraphile documentation - you have to go into the `@dataplan/pg` docs for that. So I've rectified this by adding a "registry" page to the documentation that explains what the parts of the registry are, and I've also changed the `@dataplan/pg` docs so that these different methods are hyperlinkable.

Oh... and I fixed that we were outputting `[object Object]` in an error message.