### PR TITLE
doc: fix typo

### DIFF
--- a/grafast/website/grafast/step-library/dataplan-pg/registry/example.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/registry/example.md
@@ -104,7 +104,7 @@ const builder = makeRegistryBuilder()
     isUnique: true,
   })
 
-  // A forum can have many messaegs:
+  // A forum can have many messages:
   .addRelation(forumsCodec, "messages", messagesResourceOptions, {
     localAttributes: ["id"],
     remoteAttributes: ["forum_id"],

--- a/postgraphile/website/postgraphile/config.mdx
+++ b/postgraphile/website/postgraphile/config.mdx
@@ -482,21 +482,23 @@ to determine the options that they offer.
 
 :::
 
-- `jsonScalarAsString: boolean` - if true, JSON values will be stringified
-  rather than returned as "dynamic" objects.
+- `defaultBehavior: string | undefined` - if set, applies a standard
+  [behavior](./behavior) to introspected objects.
 - `dontSwallowErrors: boolean` - if true, errors during the schema build process
   will throw rather than the system trying to recover from them. Recommended,
   but not enabled by default as it can be a barrier to entry to new users.
-- `pgJwtSecret`
-- `pgJwtSignOptions`
-- `pgUseCustomNetworkScalars: boolean` - if not false, adds the `CidrAddress`,
-  `MacAddress` and similar types for PostgreSQL network scalars.
-- `pgOrderByNullsLast: boolean | undefined` - if true, orders such that nulls are
-  always last; if false, orders such that nulls are always first; otherwise uses
-  the default ordering
+- `jsonScalarAsString: boolean` - if true, JSON values will be stringified
+  rather than returned as "dynamic" objects.
 - `pgForbidSetofFunctionsToReturnNull: boolean` - if true, setof functions
   cannot return null, so our list and connection types can be non-nullable in
   more places.
+- `pgJwtSecret`
+- `pgJwtSignOptions`
+- `pgOrderByNullsLast: boolean | undefined` - if true, orders such that nulls are
+  always last; if false, orders such that nulls are always first; otherwise uses
+  the default ordering
+- `pgUseCustomNetworkScalars: boolean` - if not false, adds the `CidrAddress`,
+  `MacAddress` and similar types for PostgreSQL network scalars.
 
 ### `grafast` options
 

--- a/postgraphile/website/postgraphile/config.mdx
+++ b/postgraphile/website/postgraphile/config.mdx
@@ -482,8 +482,9 @@ to determine the options that they offer.
 
 :::
 
-- `defaultBehavior: string | undefined` - if set, applies a standard
-  [behavior](./behavior) to introspected objects.
+- `defaultBehavior: string | undefined` - if set, applies a default
+  [behavior](./behavior) to all entities; for example to prefer lists
+  over connections: `+list -connection`.
 - `dontSwallowErrors: boolean` - if true, errors during the schema build process
   will throw rather than the system trying to recover from them. Recommended,
   but not enabled by default as it can be a barrier to entry to new users.


### PR DESCRIPTION
literally the least I could do 😅 -- I _did_ mean to find and fix a couple other doc issues but couldn't find the `next` docs here or in the graphile.github.io repo

- https://postgraphile.org/postgraphile/next/config#schema-options doesn't mention `defaultBehavior`
- smart-tags link at https://postgraphile.org/postgraphile/next/reserved-keywords/#non-unique-table-names is broken