### PR TITLE
Add Node interface to mode=single/relational interfaces

### DIFF
--- a/.changeset/friendly-melons-melt.md
+++ b/.changeset/friendly-melons-melt.md
@@ -1,0 +1,11 @@
+---
+"graphile-build-pg": patch
+"graphile-build": patch
+"postgraphile": patch
+---
+
+`@interface mode=single/relational` now get `Node` interface if the table has a
+PK.
+
+🚨 `@interface mode=union` no longer gets `Node` interface unless you also add
+`@behavior node`.

--- a/.changeset/heavy-apes-count.md
+++ b/.changeset/heavy-apes-count.md
@@ -1,0 +1,6 @@
+---
+"graphile-build-pg": patch
+"postgraphile": patch
+---
+
+Automatically register connection types for unionMember unions.

--- a/.changeset/pretty-bats-yawn.md
+++ b/.changeset/pretty-bats-yawn.md
@@ -1,0 +1,6 @@
+---
+"graphile-export": patch
+---
+
+Apply a different patch to the babel traverse issue we've been facing when
+optimizing.

--- a/graphile-build/graphile-build-pg/src/plugins/PgCustomTypeFieldPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCustomTypeFieldPlugin.ts
@@ -373,7 +373,7 @@ export const PgCustomTypeFieldPlugin: GraphileConfig.Plugin = {
                 (pgFunctionsPreferNodeId &&
                 !resource.isMutation &&
                 param.codec.attributes &&
-                finalBuild.behavior.pgCodecMatches(param.codec, "node")
+                finalBuild.behavior.pgCodecMatches(param.codec, "type:node")
                   ? "nodeId"
                   : "input");
               if (variant === "nodeId" && !param.codec.attributes) {

--- a/graphile-build/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.ts
@@ -353,7 +353,10 @@ export const PgMutationUpdateDeletePlugin: GraphileConfig.Plugin = {
                     deletedNodeIdFieldName &&
                     handler &&
                     nodeIdCodec &&
-                    build.behavior.pgCodecMatches(resource.codec, "node") &&
+                    build.behavior.pgCodecMatches(
+                      resource.codec,
+                      "type:node",
+                    ) &&
                     build.behavior.pgResourceMatches(
                       resource,
                       "delete:resource:nodeId",

--- a/graphile-build/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.ts
@@ -353,7 +353,7 @@ export const PgMutationUpdateDeletePlugin: GraphileConfig.Plugin = {
                     deletedNodeIdFieldName &&
                     handler &&
                     nodeIdCodec &&
-                    build.behavior.pgResourceMatches(resource, "node") &&
+                    build.behavior.pgCodecMatches(resource.codec, "node") &&
                     build.behavior.pgResourceMatches(
                       resource,
                       "delete:resource:nodeId",

--- a/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismPlugin.ts
@@ -69,6 +69,7 @@ declare global {
         typeIdentifier: string;
         name: string;
       };
+      isPgUnionMemberUnionConnection?: boolean;
     }
     interface ScopeEnum {
       pgPolymorphicSingleTableType?: {
@@ -76,6 +77,9 @@ declare global {
         name: string;
         attributes: ReadonlyArray<PgCodecPolymorphismSingleTypeAttributeSpec>;
       };
+    }
+    interface ScopeUnion {
+      isPgUnionMemberUnion?: boolean;
     }
   }
 }
@@ -960,6 +964,10 @@ return function (access) {
               }),
               "PgPolymorphismPlugin @unionMember unions",
             );
+            build.registerCursorConnection({
+              typeName: unionName,
+              scope: { isPgUnionMemberUnionConnection: true },
+            });
           });
         }
         return _;

--- a/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismPlugin.ts
@@ -20,18 +20,26 @@ import type {
   PgRegistry,
   PgResource,
   PgResourceOptions,
+  PgResourceUnique,
+  PgSelectSingleStep,
 } from "@dataplan/pg";
 import { assertPgClassSingleStep } from "@dataplan/pg";
+import type { ListStep } from "grafast";
 import { arraysMatch } from "grafast";
 import type {
   GraphQLInterfaceType,
   GraphQLNamedType,
   GraphQLObjectType,
 } from "grafast/graphql";
-import { gatherConfig } from "graphile-build";
+import { EXPORTABLE, gatherConfig } from "graphile-build";
+import te, { isSafeObjectPropertyName } from "tamedevil";
 
 import { getBehavior } from "../behavior.js";
-import { parseDatabaseIdentifier, parseSmartTagsOptsString } from "../utils.js";
+import {
+  parseDatabaseIdentifier,
+  parseSmartTagsOptsString,
+  tagToString,
+} from "../utils.js";
 import { version } from "../version.js";
 
 function isNotNullish<T>(v: T | null | undefined): v is T {
@@ -611,6 +619,7 @@ export const PgPolymorphismPlugin: GraphileConfig.Plugin = {
             input: {
               pgRegistry: { pgRelations },
             },
+            grafast: { arraysMatch },
           } = build;
           const { localCodec, remoteResource, isUnique, isReferencee } = entity;
           const remoteCodec = remoteResource.codec;
@@ -656,6 +665,7 @@ export const PgPolymorphismPlugin: GraphileConfig.Plugin = {
           inflection,
           options: { pgForbidSetofFunctionsToReturnNull },
           setGraphQLTypeForPgCodec,
+          grafast: { list, constant, access },
         } = build;
         const unionsToRegister = new Map<string, PgCodec[]>();
         for (const codec of build.pgCodecMetaLookup.keys()) {
@@ -682,13 +692,16 @@ export const PgPolymorphismPlugin: GraphileConfig.Plugin = {
             }
 
             const selectable = build.behavior.pgCodecMatches(codec, "select");
-            const nodeable = build.behavior.pgCodecMatches(codec, "node");
 
             if (selectable) {
               if (
                 polymorphism.mode === "single" ||
                 polymorphism.mode === "relational"
               ) {
+                const nodeable = build.behavior.pgCodecMatches(
+                  codec,
+                  "interface:node",
+                );
                 const interfaceTypeName = inflection.tableType(codec);
                 build.registerInterfaceType(
                   interfaceTypeName,
@@ -715,6 +728,27 @@ export const PgPolymorphismPlugin: GraphileConfig.Plugin = {
                   },
                   nonNullNode: pgForbidSetofFunctionsToReturnNull,
                 });
+                const resources = Object.values(
+                  build.input.pgRegistry.pgResources,
+                ).filter((r) => {
+                  if (r.codec !== codec) return false;
+                  if (r.parameters) return false;
+                  if (r.isUnique) return false;
+                  if (r.isVirtual) return false;
+                  return true;
+                });
+                const resource = resources.length === 1 ? resources[0]! : null;
+                if (resources.length !== 1) {
+                  console.warn(
+                    `Found multiple table resources for codec '${codec.name}'; we don't currently support that but we _could_ - get in touch if you need this.`,
+                  );
+                }
+                const primaryKey = resource
+                  ? (resource.uniques as PgResourceUnique[]).find(
+                      (u) => u.isPrimary === true,
+                    )
+                  : undefined;
+                const pk = primaryKey?.attributes;
                 for (const [typeIdentifier, spec] of Object.entries(
                   polymorphism.types,
                 ) as Array<
@@ -727,7 +761,10 @@ export const PgPolymorphismPlugin: GraphileConfig.Plugin = {
                   ]
                 >) {
                   const tableTypeName = spec.name;
-                  if (polymorphism.mode === "single") {
+                  if (
+                    polymorphism.mode === "single" &&
+                    build.behavior.pgCodecMatches(codec, "interface:node")
+                  ) {
                     build.registerObjectType(
                       tableTypeName,
                       {
@@ -764,16 +801,105 @@ export const PgPolymorphismPlugin: GraphileConfig.Plugin = {
                       },
                       nonNullNode: pgForbidSetofFunctionsToReturnNull,
                     });
+                    if (build.registerNodeIdHandler && resource && pk) {
+                      const clean =
+                        isSafeObjectPropertyName(tableTypeName) &&
+                        pk.every((attributeName) =>
+                          isSafeObjectPropertyName(attributeName),
+                        );
+                      build.registerNodeIdHandler({
+                        typeName: tableTypeName,
+                        codec: build.getNodeIdCodec!("base64JSON"),
+                        deprecationReason: tagToString(
+                          codec.extensions?.tags?.deprecation ??
+                            resource?.extensions?.tags?.deprecated,
+                        ),
+                        plan: clean
+                          ? // eslint-disable-next-line graphile-export/exhaustive-deps
+                            EXPORTABLE(
+                              te.run`\
+return function (list, constant) {
+  return $record => list([constant(${te.lit(tableTypeName)}, false), ${te.join(
+                                pk.map(
+                                  (attributeName) =>
+                                    te`$record.get(${te.lit(attributeName)})`,
+                                ),
+                                ", ",
+                              )}]);
+}` as any,
+                              [list, constant],
+                            )
+                          : EXPORTABLE(
+                              (constant, list, pk, tableTypeName) =>
+                                ($record: PgSelectSingleStep) => {
+                                  return list([
+                                    constant(tableTypeName, false),
+                                    ...pk.map((attribute) =>
+                                      $record.get(attribute),
+                                    ),
+                                  ]);
+                                },
+                              [constant, list, pk, tableTypeName],
+                            ),
+                        getSpec: clean
+                          ? // eslint-disable-next-line graphile-export/exhaustive-deps
+                            EXPORTABLE(
+                              te.run`\
+return function (access) {
+  return $list => ({ ${te.join(
+    pk.map(
+      (attributeName, index) =>
+        te`${te.safeKeyOrThrow(attributeName)}: access($list, [${te.lit(
+          index + 1,
+        )}])`,
+    ),
+    ", ",
+  )} });
+}` as any,
+                              [access],
+                            )
+                          : EXPORTABLE(
+                              (access, pk) => ($list: ListStep<any[]>) => {
+                                const spec = pk.reduce(
+                                  (memo, attribute, index) => {
+                                    memo[attribute] = access($list, [
+                                      index + 1,
+                                    ]);
+                                    return memo;
+                                  },
+                                  Object.create(null),
+                                );
+                                return spec;
+                              },
+                              [access, pk],
+                            ),
+                        get: EXPORTABLE(
+                          (resource) => (spec: any) => resource.get(spec),
+                          [resource],
+                        ),
+                        match: EXPORTABLE(
+                          (tableTypeName) => (obj) => {
+                            return obj[0] === tableTypeName;
+                          },
+                          [tableTypeName],
+                        ),
+                      });
+                    }
                   }
                 }
               } else if (polymorphism.mode === "union") {
                 const interfaceTypeName = inflection.tableType(codec);
+                const nodeable = build.behavior.pgCodecMatches(
+                  codec,
+                  "interface:node",
+                );
                 build.registerInterfaceType(
                   interfaceTypeName,
                   {
                     pgCodec: codec,
                     isPgPolymorphicTableType: true,
                     pgPolymorphism: polymorphism,
+                    supportsNodeInterface: nodeable,
                   },
                   () => ({
                     description: codec.description,

--- a/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismPlugin.ts
@@ -682,6 +682,7 @@ export const PgPolymorphismPlugin: GraphileConfig.Plugin = {
             }
 
             const selectable = build.behavior.pgCodecMatches(codec, "select");
+            const nodeable = build.behavior.pgCodecMatches(codec, "node");
 
             if (selectable) {
               if (
@@ -695,6 +696,8 @@ export const PgPolymorphismPlugin: GraphileConfig.Plugin = {
                     pgCodec: codec,
                     isPgPolymorphicTableType: true,
                     pgPolymorphism: polymorphism,
+                    // Since this comes from a table, if the table has the `node` interface then so should the interface
+                    supportsNodeInterface: nodeable,
                   },
                   () => ({
                     description: codec.description,

--- a/graphile-build/graphile-build-pg/src/plugins/PgRBACPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgRBACPlugin.ts
@@ -89,13 +89,7 @@ export const PgRBACPlugin: GraphileConfig.Plugin = {
           parts.push("-insert");
         }
         if (!canUpdate) {
-          if (pgAttribute.attname === "site") {
-            console.log(`Site update not allowed`);
-          }
           parts.push("-update");
-        }
-        if (pgAttribute.attname === "site") {
-          console.log(`Site tags: ${parts}`);
         }
         if (parts.length > 0) {
           attribute.extensions = attribute.extensions || Object.create(null);

--- a/graphile-build/graphile-build-pg/src/plugins/PgTableNodePlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTableNodePlugin.ts
@@ -26,6 +26,7 @@ export const PgTableNodePlugin: GraphileConfig.Plugin = {
   name: "PgTableNodePlugin",
   description: "Add the 'Node' interface to table types",
   version: version,
+  after: ["PgTablesPlugin"],
 
   schema: {
     entityBehavior: {
@@ -98,6 +99,17 @@ export const PgTableNodePlugin: GraphileConfig.Plugin = {
 
         for (const [codec, resources] of resourcesByCodec.entries()) {
           const tableTypeName = build.inflection.tableType(codec);
+          const meta = build.getTypeMetaByName(tableTypeName);
+          if (!meta) {
+            console.warn(
+              `Attempted to register node handler for '${tableTypeName}' (codec=${codec.name}), but that type wasn't registered (yet)`,
+            );
+            continue;
+          }
+          if (meta.Constructor !== build.graphql.GraphQLObjectType) {
+            // Must be an interface? Skip!
+            continue;
+          }
           if (resources.length !== 1) {
             console.warn(
               `Found multiple table resources for codec '${codec.name}'; we don't currently support that but we _could_ - get in touch if you need this.`,

--- a/graphile-build/graphile-build-pg/src/plugins/PgTableNodePlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTableNodePlugin.ts
@@ -26,7 +26,7 @@ export const PgTableNodePlugin: GraphileConfig.Plugin = {
   name: "PgTableNodePlugin",
   description: "Add the 'Node' interface to table types",
   version: version,
-  after: ["PgTablesPlugin"],
+  after: ["PgTablesPlugin", "PgPolymorphismPlugin"],
 
   schema: {
     entityBehavior: {
@@ -101,7 +101,7 @@ export const PgTableNodePlugin: GraphileConfig.Plugin = {
           const tableTypeName = build.inflection.tableType(codec);
           const meta = build.getTypeMetaByName(tableTypeName);
           if (!meta) {
-            console.warn(
+            console.trace(
               `Attempted to register node handler for '${tableTypeName}' (codec=${codec.name}), but that type wasn't registered (yet)`,
             );
             continue;

--- a/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
@@ -589,6 +589,16 @@ export const PgTablesPlugin: GraphileConfig.Plugin = {
           ];
         },
       },
+      pgResource: {
+        provides: ["default"],
+        before: ["inferred", "override"],
+        callback(behavior, resource) {
+          return [
+            ...(!resource.parameters ? ["resource:select"] : []),
+            behavior,
+          ];
+        },
+      },
     },
     hooks: {
       init(_, build, _context) {

--- a/graphile-build/graphile-build/src/global.ts
+++ b/graphile-build/graphile-build/src/global.ts
@@ -628,7 +628,13 @@ declare global {
       scope: ScopeObjectFieldsFieldArgsArg;
     }
 
-    interface ScopeInterface extends Scope {}
+    interface ScopeInterface extends Scope {
+      /**
+       * If true, 'AddNoteInterfaceToSuitableTypesPlugin' will add the `Node`
+       * interface and `id` field automatically to this interface
+       */
+      supportsNodeInterface?: boolean;
+    }
     interface ContextInterface extends Context {
       scope: ScopeInterface;
       type: "GraphQLInterfaceType";

--- a/graphile-build/graphile-build/src/global.ts
+++ b/graphile-build/graphile-build/src/global.ts
@@ -675,9 +675,7 @@ declare global {
       Self: GraphQLInterfaceType;
     }
 
-    interface ScopeUnion extends Scope {
-      isPgUnionMemberUnion?: boolean;
-    }
+    interface ScopeUnion extends Scope {}
     interface ContextUnion extends Context {
       scope: ScopeUnion;
       type: "GraphQLUnionType";

--- a/graphile-build/graphile-build/src/plugins/AddNodeInterfaceToSuitableTypesPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/AddNodeInterfaceToSuitableTypesPlugin.ts
@@ -29,14 +29,14 @@ export const AddNodeInterfaceToSuitableTypesPlugin: GraphileConfig.Plugin = {
           return interfaces;
         }
 
-        const Type = getTypeByName(inflection.builtin("Node")) as
+        const NodeInterfaceType = getTypeByName(inflection.builtin("Node")) as
           | GraphQLInterfaceType
           | undefined;
-        if (!Type) {
+        if (!NodeInterfaceType) {
           return interfaces;
         }
 
-        return [...interfaces, Type];
+        return [...interfaces, NodeInterfaceType];
       },
 
       GraphQLObjectType_fields(fields, build, context) {
@@ -59,10 +59,10 @@ export const AddNodeInterfaceToSuitableTypesPlugin: GraphileConfig.Plugin = {
           return fields;
         }
 
-        const Type = getTypeByName(inflection.builtin("Node")) as
+        const NodeInterfaceType = getTypeByName(inflection.builtin("Node")) as
           | GraphQLInterfaceType
           | undefined;
-        if (!Type) {
+        if (!NodeInterfaceType) {
           return fields;
         }
 
@@ -93,7 +93,62 @@ export const AddNodeInterfaceToSuitableTypesPlugin: GraphileConfig.Plugin = {
               ),
             },
           },
-          "Adding id field to Query type from AddNodeInterfaceToQueryPlugin",
+          `Adding id field to ${Self.name} type from AddNodeInterfaceToQueryPlugin`,
+        );
+      },
+
+      GraphQLInterfaceType_interfaces(interfaces, build, context) {
+        const { getTypeByName, inflection } = build;
+        const {
+          scope: { supportsNodeInterface },
+        } = context;
+        if (!supportsNodeInterface) {
+          return interfaces;
+        }
+
+        const NodeInterfaceType = getTypeByName(inflection.builtin("Node")) as
+          | GraphQLInterfaceType
+          | undefined;
+        if (!NodeInterfaceType) {
+          return interfaces;
+        }
+
+        return [...interfaces, NodeInterfaceType];
+      },
+
+      GraphQLInterfaceType_fields(fields, build, context) {
+        const {
+          getTypeByName,
+          inflection,
+          graphql: { GraphQLNonNull, GraphQLID },
+        } = build;
+        const {
+          Self,
+          scope: { supportsNodeInterface },
+        } = context;
+        if (!supportsNodeInterface) {
+          return fields;
+        }
+
+        const NodeInterfaceType = getTypeByName(inflection.builtin("Node")) as
+          | GraphQLInterfaceType
+          | undefined;
+        if (!NodeInterfaceType) {
+          return fields;
+        }
+
+        return build.extend(
+          fields,
+          {
+            [build.inflection.nodeIdFieldName()]: {
+              description: build.wrapDescription(
+                "A globally unique identifier. Can be used in various places throughout the system to identify this single value.",
+                "field",
+              ),
+              type: new GraphQLNonNull(GraphQLID),
+            },
+          },
+          `Adding id field to ${Self.name} interface type from AddNodeInterfaceToQueryPlugin`,
         );
       },
     },

--- a/graphile-build/graphile-build/src/plugins/NodePlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/NodePlugin.ts
@@ -102,6 +102,17 @@ export const NodePlugin: GraphileConfig.Plugin = {
                   `Node ID handler for type '${typeName}' already registered`,
                 );
               }
+              const details = build.getTypeMetaByName(typeName);
+              if (!details) {
+                throw new Error(
+                  `Attempted to register Node ID handler for type '${typeName}', but that type isn't registered (yet)`,
+                );
+              }
+              if (details.Constructor !== build.graphql.GraphQLObjectType) {
+                throw new Error(
+                  `Attempted to register Node ID handler for type '${typeName}', but that isn't an object type! (constructor: ${details.Constructor.name})`,
+                );
+              }
               nodeIdHandlerByTypeName[typeName] = handler;
             },
             getNodeIdHandler(typeName) {

--- a/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
+++ b/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
@@ -1534,6 +1534,7 @@ comment on type polymorphic.vulnerabilities is $$
 @name Vulnerability
 @behavior node
 @ref applications to:Application plural
+@ref owners to:PersonOrOrganization plural
 $$;
 
 comment on column polymorphic.vulnerabilities.id is '@notNull';
@@ -1545,12 +1546,22 @@ comment on table polymorphic.first_party_vulnerabilities is $$
 @ref applications to:Application plural
 @refVia applications via:aws_application_first_party_vulnerabilities;aws_applications
 @refVia applications via:gcp_application_first_party_vulnerabilities;gcp_applications
+@ref owners to:PersonOrOrganization plural
+@refVia owners via:aws_application_first_party_vulnerabilities;aws_applications;people
+@refVia owners via:aws_application_first_party_vulnerabilities;aws_applications;organizations
+@refVia owners via:gcp_application_first_party_vulnerabilities;gcp_applications;people
+@refVia owners via:gcp_application_first_party_vulnerabilities;gcp_applications;organizations
 $$;
 comment on table polymorphic.third_party_vulnerabilities is $$
 @implements Vulnerability
 @ref applications to:Application plural
 @refVia applications via:aws_application_third_party_vulnerabilities;aws_applications
 @refVia applications via:gcp_application_third_party_vulnerabilities;gcp_applications
+@ref owners to:PersonOrOrganization plural
+@refVia owners via:aws_application_third_party_vulnerabilities;aws_applications;people
+@refVia owners via:aws_application_third_party_vulnerabilities;aws_applications;organizations
+@refVia owners via:gcp_application_third_party_vulnerabilities;gcp_applications;people
+@refVia owners via:gcp_application_third_party_vulnerabilities;gcp_applications;organizations
 $$;
 
 create type polymorphic.zero_implementation as (

--- a/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
+++ b/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
@@ -1530,7 +1530,7 @@ comment on table polymorphic.gcp_application_first_party_vulnerabilities is '@om
 comment on table polymorphic.gcp_application_third_party_vulnerabilities is '@omit';
 
 comment on type polymorphic.vulnerabilities is $$
-@interface mode:union plural
+@interface mode:union
 @name Vulnerability
 @behavior node
 @ref applications to:Application plural

--- a/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
+++ b/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
@@ -1498,6 +1498,7 @@ create index on polymorphic.gcp_application_third_party_vulnerabilities (third_p
 comment on type polymorphic.applications is $$
 @interface mode:union
 @name Application
+@behavior node
 @ref vulnerabilities to:Vulnerability plural
 @ref owner to:PersonOrOrganization singular
 $$;
@@ -1531,6 +1532,7 @@ comment on table polymorphic.gcp_application_third_party_vulnerabilities is '@om
 comment on type polymorphic.vulnerabilities is $$
 @interface mode:union plural
 @name Vulnerability
+@behavior node
 @ref applications to:Application plural
 $$;
 
@@ -1560,6 +1562,7 @@ create type polymorphic.zero_implementation as (
 comment on type polymorphic.zero_implementation is $$
 @interface mode:union
 @name ZeroImplementation
+@behavior node
 $$;
 
 --------------------------------------------------------------------------------

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.json5
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.json5
@@ -217,4 +217,15 @@
       title: "PostGraphile version 5",
     },
   },
+  node: {
+    __typename: "SingleTableDivider",
+    id: 3,
+    nodeId: "WyJTaW5nbGVUYWJsZURpdmlkZXIiLDNd",
+    type: "DIVIDER",
+    rootTopicId: 1,
+    rootTopic: {
+      id: 1,
+      title: "PostGraphile version 5",
+    },
+  },
 }

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.json5
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.json5
@@ -3,18 +3,21 @@
     nodes: [
       {
         id: 1,
+        nodeId: "WyJTaW5nbGVUYWJsZVRvcGljIiwxXQ==",
         type: "TOPIC",
         rootTopicId: null,
         rootTopic: null,
       },
       {
         id: 2,
+        nodeId: "WyJTaW5nbGVUYWJsZVRvcGljIiwyXQ==",
         type: "TOPIC",
         rootTopicId: null,
         rootTopic: null,
       },
       {
         id: 3,
+        nodeId: "WyJTaW5nbGVUYWJsZURpdmlkZXIiLDNd",
         type: "DIVIDER",
         rootTopicId: 1,
         rootTopic: {
@@ -24,6 +27,7 @@
       },
       {
         id: 4,
+        nodeId: "WyJTaW5nbGVUYWJsZVBvc3QiLDRd",
         type: "POST",
         rootTopicId: 1,
         rootTopic: {
@@ -33,6 +37,7 @@
       },
       {
         id: 5,
+        nodeId: "WyJTaW5nbGVUYWJsZVBvc3QiLDVd",
         type: "POST",
         rootTopicId: 1,
         rootTopic: {
@@ -42,6 +47,7 @@
       },
       {
         id: 6,
+        nodeId: "WyJTaW5nbGVUYWJsZVBvc3QiLDZd",
         type: "POST",
         rootTopicId: 1,
         rootTopic: {
@@ -51,6 +57,7 @@
       },
       {
         id: 7,
+        nodeId: "WyJTaW5nbGVUYWJsZVBvc3QiLDdd",
         type: "POST",
         rootTopicId: 1,
         rootTopic: {
@@ -60,6 +67,7 @@
       },
       {
         id: 8,
+        nodeId: "WyJTaW5nbGVUYWJsZURpdmlkZXIiLDhd",
         type: "DIVIDER",
         rootTopicId: 1,
         rootTopic: {
@@ -69,6 +77,7 @@
       },
       {
         id: 9,
+        nodeId: "WyJTaW5nbGVUYWJsZVBvc3QiLDld",
         type: "POST",
         rootTopicId: 1,
         rootTopic: {
@@ -78,6 +87,7 @@
       },
       {
         id: 10,
+        nodeId: "WyJTaW5nbGVUYWJsZVRvcGljIiwxMF0=",
         type: "TOPIC",
         rootTopicId: 1,
         rootTopic: {
@@ -87,6 +97,7 @@
       },
       {
         id: 11,
+        nodeId: "WyJTaW5nbGVUYWJsZVRvcGljIiwxMV0=",
         type: "TOPIC",
         rootTopicId: 1,
         rootTopic: {
@@ -96,6 +107,7 @@
       },
       {
         id: 12,
+        nodeId: "WyJTaW5nbGVUYWJsZVBvc3QiLDEyXQ==",
         type: "POST",
         rootTopicId: 1,
         rootTopic: {
@@ -105,6 +117,7 @@
       },
       {
         id: 13,
+        nodeId: "WyJTaW5nbGVUYWJsZVBvc3QiLDEzXQ==",
         type: "POST",
         rootTopicId: 1,
         rootTopic: {
@@ -114,6 +127,7 @@
       },
       {
         id: 14,
+        nodeId: "WyJTaW5nbGVUYWJsZVBvc3QiLDE0XQ==",
         type: "POST",
         rootTopicId: 1,
         rootTopic: {
@@ -123,6 +137,7 @@
       },
       {
         id: 15,
+        nodeId: "WyJTaW5nbGVUYWJsZVBvc3QiLDE1XQ==",
         type: "POST",
         rootTopicId: 2,
         rootTopic: {
@@ -132,6 +147,7 @@
       },
       {
         id: 16,
+        nodeId: "WyJTaW5nbGVUYWJsZUNoZWNrbGlzdCIsMTZd",
         type: "CHECKLIST",
         rootTopicId: 1,
         rootTopic: {
@@ -141,6 +157,7 @@
       },
       {
         id: 17,
+        nodeId: "WyJTaW5nbGVUYWJsZUNoZWNrbGlzdEl0ZW0iLDE3XQ==",
         type: "CHECKLIST_ITEM",
         rootTopicId: 1,
         rootTopic: {
@@ -150,6 +167,7 @@
       },
       {
         id: 18,
+        nodeId: "WyJTaW5nbGVUYWJsZUNoZWNrbGlzdEl0ZW0iLDE4XQ==",
         type: "CHECKLIST_ITEM",
         rootTopicId: 1,
         rootTopic: {
@@ -159,6 +177,7 @@
       },
       {
         id: 19,
+        nodeId: "WyJTaW5nbGVUYWJsZUNoZWNrbGlzdEl0ZW0iLDE5XQ==",
         type: "CHECKLIST_ITEM",
         rootTopicId: 1,
         rootTopic: {
@@ -168,6 +187,7 @@
       },
       {
         id: 20,
+        nodeId: "WyJTaW5nbGVUYWJsZUNoZWNrbGlzdEl0ZW0iLDIwXQ==",
         type: "CHECKLIST_ITEM",
         rootTopicId: 1,
         rootTopic: {
@@ -177,6 +197,7 @@
       },
       {
         id: 21,
+        nodeId: "WyJTaW5nbGVUYWJsZUNoZWNrbGlzdEl0ZW0iLDIxXQ==",
         type: "CHECKLIST_ITEM",
         rootTopicId: 1,
         rootTopic: {
@@ -185,5 +206,15 @@
         },
       },
     ],
+  },
+  singleTableDivider: {
+    id: 3,
+    nodeId: "WyJTaW5nbGVUYWJsZURpdmlkZXIiLDNd",
+    type: "DIVIDER",
+    rootTopicId: 1,
+    rootTopic: {
+      id: 1,
+      title: "PostGraphile version 5",
+    },
   },
 }

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.mermaid
@@ -20,16 +20,121 @@ graph TD
     __Value3 --> Access16
     __Value3 --> Access17
     Lambda104{{"Lambda[104∈0]<br />ᐸspecifier_SingleTableDivider_base64JSONᐳ"}}:::plan
-    Constant130{{"Constant[130∈0]<br />ᐸ'WyJTaW5nbGVUYWJsZURpdmlkZXIiLDNd'ᐳ"}}:::plan
-    Constant130 --> Lambda104
+    Constant296{{"Constant[296∈0]<br />ᐸ'WyJTaW5nbGVUYWJsZURpdmlkZXIiLDNd'ᐳ"}}:::plan
+    Constant296 --> Lambda104
     Lambda104 --> Access105
     First110{{"First[110∈0]"}}:::plan
     PgSelect106 --> First110
     PgSelectSingle111{{"PgSelectSingle[111∈0]<br />ᐸsingle_table_itemsᐳ"}}:::plan
     First110 --> PgSelectSingle111
+    Lambda130{{"Lambda[130∈0]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
+    Constant296 --> Lambda130
+    Node129{{"Node[129∈0]"}}:::plan
+    Lambda130 --> Node129
     __Value0["__Value[0∈0]"]:::plan
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
     Connection19{{"Connection[19∈0]<br />ᐸ15ᐳ"}}:::plan
+    PgSelect133[["PgSelect[133∈7]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
+    Access297{{"Access[297∈7]<br />ᐸ130.base64JSON.1ᐳ<br />ᐳSingleTableTopic<br />ᐳPerson<br />ᐳLogEntry<br />ᐳOrganization<br />ᐳAwsApplication<br />ᐳGcpApplication<br />ᐳSingleTablePost<br />ᐳPriority<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability"}}:::plan
+    Object18 & Access297 --> PgSelect133
+    PgSelect141[["PgSelect[141∈7]<br />ᐸpeopleᐳ<br />ᐳPerson"]]:::plan
+    Object18 & Access297 --> PgSelect141
+    PgSelect149[["PgSelect[149∈7]<br />ᐸlog_entriesᐳ<br />ᐳLogEntry"]]:::plan
+    Object18 & Access297 --> PgSelect149
+    PgSelect157[["PgSelect[157∈7]<br />ᐸorganizationsᐳ<br />ᐳOrganization"]]:::plan
+    Object18 & Access297 --> PgSelect157
+    PgSelect165[["PgSelect[165∈7]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
+    Object18 & Access297 --> PgSelect165
+    PgSelect173[["PgSelect[173∈7]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
+    Object18 & Access297 --> PgSelect173
+    PgSelect189[["PgSelect[189∈7]<br />ᐸprioritiesᐳ<br />ᐳPriority"]]:::plan
+    Object18 & Access297 --> PgSelect189
+    List206{{"List[206∈7]<br />ᐸ204,203ᐳ<br />ᐳSingleTableDivider"}}:::plan
+    Constant204{{"Constant[204∈7]<br />ᐸ'SingleTableDivider'ᐳ<br />ᐳSingleTableDivider"}}:::plan
+    PgClassExpression203{{"PgClassExpression[203∈7]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableDivider"}}:::plan
+    Constant204 & PgClassExpression203 --> List206
+    PgSelect237[["PgSelect[237∈7]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
+    Object18 & Access297 --> PgSelect237
+    PgSelect245[["PgSelect[245∈7]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
+    Object18 & Access297 --> PgSelect245
+    PgSelect253[["PgSelect[253∈7]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
+    Object18 & Access297 --> PgSelect253
+    PgSelect261[["PgSelect[261∈7]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
+    Object18 & Access297 --> PgSelect261
+    PgSelect269[["PgSelect[269∈7]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
+    Object18 & Access297 --> PgSelect269
+    PgSelect278[["PgSelect[278∈7]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
+    Object18 & Access297 --> PgSelect278
+    PgSelect286[["PgSelect[286∈7]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
+    Object18 & Access297 --> PgSelect286
+    Lambda130 --> Access297
+    First137{{"First[137∈7]"}}:::plan
+    PgSelect133 --> First137
+    PgSelectSingle138{{"PgSelectSingle[138∈7]<br />ᐸsingle_table_itemsᐳ"}}:::plan
+    First137 --> PgSelectSingle138
+    First145{{"First[145∈7]"}}:::plan
+    PgSelect141 --> First145
+    PgSelectSingle146{{"PgSelectSingle[146∈7]<br />ᐸpeopleᐳ"}}:::plan
+    First145 --> PgSelectSingle146
+    First153{{"First[153∈7]"}}:::plan
+    PgSelect149 --> First153
+    PgSelectSingle154{{"PgSelectSingle[154∈7]<br />ᐸlog_entriesᐳ"}}:::plan
+    First153 --> PgSelectSingle154
+    First161{{"First[161∈7]"}}:::plan
+    PgSelect157 --> First161
+    PgSelectSingle162{{"PgSelectSingle[162∈7]<br />ᐸorganizationsᐳ"}}:::plan
+    First161 --> PgSelectSingle162
+    First169{{"First[169∈7]"}}:::plan
+    PgSelect165 --> First169
+    PgSelectSingle170{{"PgSelectSingle[170∈7]<br />ᐸaws_applicationsᐳ"}}:::plan
+    First169 --> PgSelectSingle170
+    First177{{"First[177∈7]"}}:::plan
+    PgSelect173 --> First177
+    PgSelectSingle178{{"PgSelectSingle[178∈7]<br />ᐸgcp_applicationsᐳ"}}:::plan
+    First177 --> PgSelectSingle178
+    First193{{"First[193∈7]"}}:::plan
+    PgSelect189 --> First193
+    PgSelectSingle194{{"PgSelectSingle[194∈7]<br />ᐸprioritiesᐳ"}}:::plan
+    First193 --> PgSelectSingle194
+    PgSelectSingle138 --> PgClassExpression203
+    Lambda207{{"Lambda[207∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List206 --> Lambda207
+    PgClassExpression208{{"PgClassExpression[208∈7]<br />ᐸ__single_t...s__.”type”ᐳ<br />ᐳSingleTableDivider"}}:::plan
+    PgSelectSingle138 --> PgClassExpression208
+    PgClassExpression209{{"PgClassExpression[209∈7]<br />ᐸ__single_t..._topic_id”ᐳ<br />ᐳSingleTableDivider"}}:::plan
+    PgSelectSingle138 --> PgClassExpression209
+    RemapKeys294{{"RemapKeys[294∈7]<br />ᐸ138:{”0”:2,”1”:3,”2”:4}ᐳ<br />ᐳSingleTableDivider"}}:::plan
+    PgSelectSingle138 --> RemapKeys294
+    PgSelectSingle216{{"PgSelectSingle[216∈7]<br />ᐸsingle_table_itemsᐳ"}}:::plan
+    RemapKeys294 --> PgSelectSingle216
+    First241{{"First[241∈7]"}}:::plan
+    PgSelect237 --> First241
+    PgSelectSingle242{{"PgSelectSingle[242∈7]<br />ᐸrelational_topicsᐳ"}}:::plan
+    First241 --> PgSelectSingle242
+    First249{{"First[249∈7]"}}:::plan
+    PgSelect245 --> First249
+    PgSelectSingle250{{"PgSelectSingle[250∈7]<br />ᐸrelational_postsᐳ"}}:::plan
+    First249 --> PgSelectSingle250
+    First257{{"First[257∈7]"}}:::plan
+    PgSelect253 --> First257
+    PgSelectSingle258{{"PgSelectSingle[258∈7]<br />ᐸrelational_dividersᐳ"}}:::plan
+    First257 --> PgSelectSingle258
+    First265{{"First[265∈7]"}}:::plan
+    PgSelect261 --> First265
+    PgSelectSingle266{{"PgSelectSingle[266∈7]<br />ᐸrelational_checklistsᐳ"}}:::plan
+    First265 --> PgSelectSingle266
+    First273{{"First[273∈7]"}}:::plan
+    PgSelect269 --> First273
+    PgSelectSingle274{{"PgSelectSingle[274∈7]<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
+    First273 --> PgSelectSingle274
+    First282{{"First[282∈7]"}}:::plan
+    PgSelect278 --> First282
+    PgSelectSingle283{{"PgSelectSingle[283∈7]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
+    First282 --> PgSelectSingle283
+    First290{{"First[290∈7]"}}:::plan
+    PgSelect286 --> First290
+    PgSelectSingle291{{"PgSelectSingle[291∈7]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
+    First290 --> PgSelectSingle291
     List115{{"List[115∈5]<br />ᐸ113,112ᐳ"}}:::plan
     Constant113{{"Constant[113∈5]<br />ᐸ'SingleTableDivider'ᐳ"}}:::plan
     PgClassExpression112{{"PgClassExpression[112∈5]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
@@ -41,10 +146,10 @@ graph TD
     PgSelectSingle111 --> PgClassExpression117
     PgClassExpression118{{"PgClassExpression[118∈5]<br />ᐸ__single_t..._topic_id”ᐳ"}}:::plan
     PgSelectSingle111 --> PgClassExpression118
-    RemapKeys128{{"RemapKeys[128∈5]<br />ᐸ111:{”0”:2,”1”:3,”2”:4}ᐳ"}}:::plan
-    PgSelectSingle111 --> RemapKeys128
+    RemapKeys292{{"RemapKeys[292∈5]<br />ᐸ111:{”0”:2,”1”:3,”2”:4}ᐳ"}}:::plan
+    PgSelectSingle111 --> RemapKeys292
     PgSelectSingle125{{"PgSelectSingle[125∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
-    RemapKeys128 --> PgSelectSingle125
+    RemapKeys292 --> PgSelectSingle125
     PgSelect20[["PgSelect[20∈1]<br />ᐸsingle_table_itemsᐳ"]]:::plan
     Object18 & Connection19 --> PgSelect20
     __Item21[/"__Item[21∈2]<br />ᐸ20ᐳ"\]:::itemplan
@@ -61,6 +166,10 @@ graph TD
     PgSelectSingle125 --> PgClassExpression126
     PgClassExpression127{{"PgClassExpression[127∈6]<br />ᐸ__single_t...__.”title”ᐳ"}}:::plan
     PgSelectSingle125 --> PgClassExpression127
+    PgClassExpression217{{"PgClassExpression[217∈8]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression217
+    PgClassExpression218{{"PgClassExpression[218∈8]<br />ᐸ__single_t...__.”title”ᐳ"}}:::plan
+    PgSelectSingle216 --> PgClassExpression218
     List26{{"List[26∈3]<br />ᐸ24,23ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Constant24{{"Constant[24∈3]<br />ᐸ'SingleTableTopic'ᐳ<br />ᐳSingleTableTopic"}}:::plan
     Constant24 & PgClassExpression23 --> List26
@@ -100,9 +209,9 @@ graph TD
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/simple-single-table-items-root-topic"
-    Bucket0("Bucket 0 (root)<br />1: <br />ᐳ: 16, 17, 19, 130, 18, 104, 105<br />2: PgSelect[106]<br />ᐳ: First[110], PgSelectSingle[111]"):::bucket
+    Bucket0("Bucket 0 (root)<br />1: <br />ᐳ: 16, 17, 19, 296, 18, 104, 105, 130, 129<br />2: PgSelect[106]<br />ᐳ: First[110], PgSelectSingle[111]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Lambda104,Access105,PgSelect106,First110,PgSelectSingle111,Constant130 bucket0
+    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Lambda104,Access105,PgSelect106,First110,PgSelectSingle111,Node129,Lambda130,Constant296 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 18, 19<br /><br />ROOT Connectionᐸ15ᐳ[19]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect20 bucket1
@@ -117,13 +226,20 @@ graph TD
     class Bucket4,PgClassExpression37,PgClassExpression38 bucket4
     Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 111<br /><br />ROOT PgSelectSingleᐸsingle_table_itemsᐳ[111]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgClassExpression112,Constant113,List115,Lambda116,PgClassExpression117,PgClassExpression118,PgSelectSingle125,RemapKeys128 bucket5
+    class Bucket5,PgClassExpression112,Constant113,List115,Lambda116,PgClassExpression117,PgClassExpression118,PgSelectSingle125,RemapKeys292 bucket5
     Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 125<br /><br />ROOT PgSelectSingle{5}ᐸsingle_table_itemsᐳ[125]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,PgClassExpression126,PgClassExpression127 bucket6
-    Bucket0 --> Bucket1 & Bucket5
+    Bucket7("Bucket 7 (polymorphic)<br />SingleTableTopic,Person,LogEntry,Organization,AwsApplication,GcpApplication,SingleTablePost,Priority,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem,RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem,Query,FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 18, 130, 129, 5<br />ᐳSingleTableTopic<br />ᐳPerson<br />ᐳLogEntry<br />ᐳOrganization<br />ᐳAwsApplication<br />ᐳGcpApplication<br />ᐳSingleTablePost<br />ᐳPriority<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br />ᐳQuery<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br />1: <br />ᐳ: Constant[204], Access[297]<br />2: 133, 141, 149, 157, 165, 173, 189, 237, 245, 253, 261, 269, 278, 286<br />ᐳ: 137, 138, 145, 146, 153, 154, 161, 162, 169, 170, 177, 178, 193, 194, 203, 206, 207, 208, 209, 241, 242, 249, 250, 257, 258, 265, 266, 273, 274, 282, 283, 290, 291, 294, 216"):::bucket
+    classDef bucket7 stroke:#808000
+    class Bucket7,PgSelect133,First137,PgSelectSingle138,PgSelect141,First145,PgSelectSingle146,PgSelect149,First153,PgSelectSingle154,PgSelect157,First161,PgSelectSingle162,PgSelect165,First169,PgSelectSingle170,PgSelect173,First177,PgSelectSingle178,PgSelect189,First193,PgSelectSingle194,PgClassExpression203,Constant204,List206,Lambda207,PgClassExpression208,PgClassExpression209,PgSelectSingle216,PgSelect237,First241,PgSelectSingle242,PgSelect245,First249,PgSelectSingle250,PgSelect253,First257,PgSelectSingle258,PgSelect261,First265,PgSelectSingle266,PgSelect269,First273,PgSelectSingle274,PgSelect278,First282,PgSelectSingle283,PgSelect286,First290,PgSelectSingle291,RemapKeys294,Access297 bucket7
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 216<br /><br />ROOT PgSelectSingle{7}ᐸsingle_table_itemsᐳ[216]"):::bucket
+    classDef bucket8 stroke:#dda0dd
+    class Bucket8,PgClassExpression217,PgClassExpression218 bucket8
+    Bucket0 --> Bucket1 & Bucket5 & Bucket7
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3
     Bucket3 --> Bucket4
     Bucket5 --> Bucket6
+    Bucket7 --> Bucket8
     end

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.mermaid
@@ -13,12 +13,38 @@ graph TD
     Access16{{"Access[16∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
     Access17{{"Access[17∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
     Access16 & Access17 --> Object18
+    PgSelect106[["PgSelect[106∈0]<br />ᐸsingle_table_itemsᐳ"]]:::plan
+    Access105{{"Access[105∈0]<br />ᐸ104.1ᐳ"}}:::plan
+    Object18 & Access105 --> PgSelect106
     __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
     __Value3 --> Access16
     __Value3 --> Access17
+    Lambda104{{"Lambda[104∈0]<br />ᐸspecifier_SingleTableDivider_base64JSONᐳ"}}:::plan
+    Constant130{{"Constant[130∈0]<br />ᐸ'WyJTaW5nbGVUYWJsZURpdmlkZXIiLDNd'ᐳ"}}:::plan
+    Constant130 --> Lambda104
+    Lambda104 --> Access105
+    First110{{"First[110∈0]"}}:::plan
+    PgSelect106 --> First110
+    PgSelectSingle111{{"PgSelectSingle[111∈0]<br />ᐸsingle_table_itemsᐳ"}}:::plan
+    First110 --> PgSelectSingle111
     __Value0["__Value[0∈0]"]:::plan
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
     Connection19{{"Connection[19∈0]<br />ᐸ15ᐳ"}}:::plan
+    List115{{"List[115∈5]<br />ᐸ113,112ᐳ"}}:::plan
+    Constant113{{"Constant[113∈5]<br />ᐸ'SingleTableDivider'ᐳ"}}:::plan
+    PgClassExpression112{{"PgClassExpression[112∈5]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    Constant113 & PgClassExpression112 --> List115
+    PgSelectSingle111 --> PgClassExpression112
+    Lambda116{{"Lambda[116∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List115 --> Lambda116
+    PgClassExpression117{{"PgClassExpression[117∈5]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle111 --> PgClassExpression117
+    PgClassExpression118{{"PgClassExpression[118∈5]<br />ᐸ__single_t..._topic_id”ᐳ"}}:::plan
+    PgSelectSingle111 --> PgClassExpression118
+    RemapKeys128{{"RemapKeys[128∈5]<br />ᐸ111:{”0”:2,”1”:3,”2”:4}ᐳ"}}:::plan
+    PgSelectSingle111 --> RemapKeys128
+    PgSelectSingle125{{"PgSelectSingle[125∈5]<br />ᐸsingle_table_itemsᐳ"}}:::plan
+    RemapKeys128 --> PgSelectSingle125
     PgSelect20[["PgSelect[20∈1]<br />ᐸsingle_table_itemsᐳ"]]:::plan
     Object18 & Connection19 --> PgSelect20
     __Item21[/"__Item[21∈2]<br />ᐸ20ᐳ"\]:::itemplan
@@ -27,41 +53,77 @@ graph TD
     __Item21 --> PgSelectSingle22
     PgClassExpression23{{"PgClassExpression[23∈2]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
     PgSelectSingle22 --> PgClassExpression23
-    PgClassExpression24{{"PgClassExpression[24∈2]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle22 --> PgClassExpression24
-    PgClassExpression25{{"PgClassExpression[25∈2]<br />ᐸ__single_t..._topic_id”ᐳ"}}:::plan
-    PgSelectSingle22 --> PgClassExpression25
-    PgSelect27[["PgSelect[27∈3]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    Object18 & PgClassExpression25 --> PgSelect27
-    First31{{"First[31∈3]"}}:::plan
-    PgSelect27 --> First31
-    PgSelectSingle32{{"PgSelectSingle[32∈3]<br />ᐸsingle_table_itemsᐳ"}}:::plan
-    First31 --> PgSelectSingle32
-    PgClassExpression33{{"PgClassExpression[33∈4]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
-    PgSelectSingle32 --> PgClassExpression33
-    PgClassExpression34{{"PgClassExpression[34∈4]<br />ᐸ__single_t...__.”title”ᐳ"}}:::plan
-    PgSelectSingle32 --> PgClassExpression34
+    PgClassExpression28{{"PgClassExpression[28∈2]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle22 --> PgClassExpression28
+    PgClassExpression29{{"PgClassExpression[29∈2]<br />ᐸ__single_t..._topic_id”ᐳ"}}:::plan
+    PgSelectSingle22 --> PgClassExpression29
+    PgClassExpression126{{"PgClassExpression[126∈6]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle125 --> PgClassExpression126
+    PgClassExpression127{{"PgClassExpression[127∈6]<br />ᐸ__single_t...__.”title”ᐳ"}}:::plan
+    PgSelectSingle125 --> PgClassExpression127
+    List26{{"List[26∈3]<br />ᐸ24,23ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    Constant24{{"Constant[24∈3]<br />ᐸ'SingleTableTopic'ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    Constant24 & PgClassExpression23 --> List26
+    PgSelect31[["PgSelect[31∈3]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
+    Object18 & PgClassExpression29 --> PgSelect31
+    List42{{"List[42∈3]<br />ᐸ40,23ᐳ<br />ᐳSingleTablePost"}}:::plan
+    Constant40{{"Constant[40∈3]<br />ᐸ'SingleTablePost'ᐳ<br />ᐳSingleTablePost"}}:::plan
+    Constant40 & PgClassExpression23 --> List42
+    List58{{"List[58∈3]<br />ᐸ56,23ᐳ<br />ᐳSingleTableDivider"}}:::plan
+    Constant56{{"Constant[56∈3]<br />ᐸ'SingleTableDivider'ᐳ<br />ᐳSingleTableDivider"}}:::plan
+    Constant56 & PgClassExpression23 --> List58
+    List74{{"List[74∈3]<br />ᐸ72,23ᐳ<br />ᐳSingleTableChecklist"}}:::plan
+    Constant72{{"Constant[72∈3]<br />ᐸ'SingleTableChecklist'ᐳ<br />ᐳSingleTableChecklist"}}:::plan
+    Constant72 & PgClassExpression23 --> List74
+    List90{{"List[90∈3]<br />ᐸ88,23ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
+    Constant88{{"Constant[88∈3]<br />ᐸ'SingleTableChecklistItem'ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
+    Constant88 & PgClassExpression23 --> List90
+    Lambda27{{"Lambda[27∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List26 --> Lambda27
+    First35{{"First[35∈3]"}}:::plan
+    PgSelect31 --> First35
+    PgSelectSingle36{{"PgSelectSingle[36∈3]<br />ᐸsingle_table_itemsᐳ"}}:::plan
+    First35 --> PgSelectSingle36
+    Lambda43{{"Lambda[43∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List42 --> Lambda43
+    Lambda59{{"Lambda[59∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List58 --> Lambda59
+    Lambda75{{"Lambda[75∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List74 --> Lambda75
+    Lambda91{{"Lambda[91∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List90 --> Lambda91
+    PgClassExpression37{{"PgClassExpression[37∈4]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle36 --> PgClassExpression37
+    PgClassExpression38{{"PgClassExpression[38∈4]<br />ᐸ__single_t...__.”title”ᐳ"}}:::plan
+    PgSelectSingle36 --> PgClassExpression38
 
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/simple-single-table-items-root-topic"
-    Bucket0("Bucket 0 (root)"):::bucket
+    Bucket0("Bucket 0 (root)<br />1: <br />ᐳ: 16, 17, 19, 130, 18, 104, 105<br />2: PgSelect[106]<br />ᐳ: First[110], PgSelectSingle[111]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19 bucket0
+    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Lambda104,Access105,PgSelect106,First110,PgSelectSingle111,Constant130 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 18, 19<br /><br />ROOT Connectionᐸ15ᐳ[19]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect20 bucket1
     Bucket2("Bucket 2 (listItem)<br />Deps: 18<br /><br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,__Item21,PgSelectSingle22,PgClassExpression23,PgClassExpression24,PgClassExpression25 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 18, 25, 22, 23, 24<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
+    class Bucket2,__Item21,PgSelectSingle22,PgClassExpression23,PgClassExpression28,PgClassExpression29 bucket2
+    Bucket3("Bucket 3 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 23, 18, 29, 22, 28<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgSelect27,First31,PgSelectSingle32 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 32<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[32]"):::bucket
+    class Bucket3,Constant24,List26,Lambda27,PgSelect31,First35,PgSelectSingle36,Constant40,List42,Lambda43,Constant56,List58,Lambda59,Constant72,List74,Lambda75,Constant88,List90,Lambda91 bucket3
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 36<br /><br />ROOT PgSelectSingle{3}ᐸsingle_table_itemsᐳ[36]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgClassExpression33,PgClassExpression34 bucket4
-    Bucket0 --> Bucket1
+    class Bucket4,PgClassExpression37,PgClassExpression38 bucket4
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 111<br /><br />ROOT PgSelectSingleᐸsingle_table_itemsᐳ[111]"):::bucket
+    classDef bucket5 stroke:#7fff00
+    class Bucket5,PgClassExpression112,Constant113,List115,Lambda116,PgClassExpression117,PgClassExpression118,PgSelectSingle125,RemapKeys128 bucket5
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 125<br /><br />ROOT PgSelectSingle{5}ᐸsingle_table_itemsᐳ[125]"):::bucket
+    classDef bucket6 stroke:#ff1493
+    class Bucket6,PgClassExpression126,PgClassExpression127 bucket6
+    Bucket0 --> Bucket1 & Bucket5
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3
     Bucket3 --> Bucket4
+    Bucket5 --> Bucket6
     end

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.sql
@@ -1,3 +1,22 @@
+select __single_table_items_result__.*
+from (select 0 as idx, $1::"int4" as "id0") as __single_table_items_identifiers__,
+lateral (
+  select
+    __single_table_items__."id"::text as "0",
+    __single_table_items__."type"::text as "1",
+    __single_table_items_2."id"::text as "2",
+    __single_table_items_2."title" as "3",
+    __single_table_items_2."type"::text as "4",
+    __single_table_items__."root_topic_id"::text as "5",
+    __single_table_items_identifiers__.idx as "6"
+  from "polymorphic"."single_table_items" as __single_table_items__
+  left outer join "polymorphic"."single_table_items" as __single_table_items_2
+  on (__single_table_items__."root_topic_id"::"int4" = __single_table_items_2."id")
+  where (
+    __single_table_items__."id" = __single_table_items_identifiers__."id0"
+  )
+) as __single_table_items_result__;
+
 select
   __single_table_items__."id"::text as "0",
   __single_table_items__."type"::text as "1",

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.test.graphql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.test.graphql
@@ -25,4 +25,17 @@
       title
     }
   }
+  node(nodeId: "WyJTaW5nbGVUYWJsZURpdmlkZXIiLDNd") {
+    __typename
+    ... on SingleTableDivider {
+      id
+      nodeId
+      type
+      rootTopicId
+      rootTopic {
+        id
+        title
+      }
+    }
+  }
 }

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.test.graphql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.test.graphql
@@ -6,12 +6,23 @@
   allSingleTableItems {
     nodes {
       id
+      nodeId
       type
       rootTopicId
       rootTopic {
         id
         title
       }
+    }
+  }
+  singleTableDivider(nodeId: "WyJTaW5nbGVUYWJsZURpdmlkZXIiLDNd") {
+    id
+    nodeId
+    type
+    rootTopicId
+    rootTopic {
+      id
+      title
     }
   }
 }

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.json5
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.json5
@@ -1,0 +1,262 @@
+{
+  allVulnerabilities: {
+    nodes: [
+      {
+        id: "WyJmaXJzdF9wYXJ0eV92dWxuZXJhYmlsaXRpZXMiLDFd",
+        name: "Off-by-one",
+        applications: {
+          nodes: [
+            {
+              id: "WyJhd3NfYXBwbGljYXRpb25zIiwxXQ==",
+              name: "AWS App 1",
+              owner: {
+                __typename: "Organization",
+                id: "WyJvcmdhbml6YXRpb25zIiwxXQ==",
+                name: "Acme",
+              },
+            },
+            {
+              id: "WyJhd3NfYXBwbGljYXRpb25zIiwzXQ==",
+              name: "AWS App 3",
+              owner: {
+                __typename: "Organization",
+                id: "WyJvcmdhbml6YXRpb25zIiwxXQ==",
+                name: "Acme",
+              },
+            },
+            {
+              id: "WyJhd3NfYXBwbGljYXRpb25zIiw2XQ==",
+              name: "AWS App 6",
+              owner: {
+                __typename: "Person",
+                id: "WyJwZW9wbGUiLDFd",
+                username: "Alice",
+              },
+            },
+            {
+              id: "WyJhd3NfYXBwbGljYXRpb25zIiw3XQ==",
+              name: "SAC-NORAD AI",
+              owner: {
+                __typename: "Organization",
+                id: "WyJvcmdhbml6YXRpb25zIiw1XQ==",
+                name: "Cyberdyne Systems",
+              },
+            },
+            {
+              id: "WyJnY3BfYXBwbGljYXRpb25zIiw0XQ==",
+              name: "Gargantual Crap Pile",
+              owner: {
+                __typename: "Person",
+                id: "WyJwZW9wbGUiLDJd",
+                username: "Benjie",
+              },
+            },
+          ],
+        },
+        applicationsList: [
+          {
+            id: "WyJhd3NfYXBwbGljYXRpb25zIiwxXQ==",
+            name: "AWS App 1",
+            owner: {
+              __typename: "Organization",
+              id: "WyJvcmdhbml6YXRpb25zIiwxXQ==",
+              name: "Acme",
+            },
+          },
+          {
+            id: "WyJhd3NfYXBwbGljYXRpb25zIiwzXQ==",
+            name: "AWS App 3",
+            owner: {
+              __typename: "Organization",
+              id: "WyJvcmdhbml6YXRpb25zIiwxXQ==",
+              name: "Acme",
+            },
+          },
+          {
+            id: "WyJhd3NfYXBwbGljYXRpb25zIiw2XQ==",
+            name: "AWS App 6",
+            owner: {
+              __typename: "Person",
+              id: "WyJwZW9wbGUiLDFd",
+              username: "Alice",
+            },
+          },
+          {
+            id: "WyJhd3NfYXBwbGljYXRpb25zIiw3XQ==",
+            name: "SAC-NORAD AI",
+            owner: {
+              __typename: "Organization",
+              id: "WyJvcmdhbml6YXRpb25zIiw1XQ==",
+              name: "Cyberdyne Systems",
+            },
+          },
+          {
+            id: "WyJnY3BfYXBwbGljYXRpb25zIiw0XQ==",
+            name: "Gargantual Crap Pile",
+            owner: {
+              __typename: "Person",
+              id: "WyJwZW9wbGUiLDJd",
+              username: "Benjie",
+            },
+          },
+        ],
+        owners: {
+          nodes: [
+            {
+              __typename: "Organization",
+              id: "WyJvcmdhbml6YXRpb25zIiwxXQ==",
+              name: "Acme",
+            },
+            {
+              __typename: "Organization",
+              id: "WyJvcmdhbml6YXRpb25zIiwxXQ==",
+              name: "Acme",
+            },
+            {
+              __typename: "Organization",
+              id: "WyJvcmdhbml6YXRpb25zIiw1XQ==",
+              name: "Cyberdyne Systems",
+            },
+            {
+              __typename: "Person",
+              id: "WyJwZW9wbGUiLDFd",
+              username: "Alice",
+            },
+            {
+              __typename: "Person",
+              id: "WyJwZW9wbGUiLDJd",
+              username: "Benjie",
+            },
+          ],
+        },
+        ownersList: [
+          {
+            __typename: "Organization",
+            id: "WyJvcmdhbml6YXRpb25zIiwxXQ==",
+            name: "Acme",
+          },
+          {
+            __typename: "Organization",
+            id: "WyJvcmdhbml6YXRpb25zIiwxXQ==",
+            name: "Acme",
+          },
+          {
+            __typename: "Organization",
+            id: "WyJvcmdhbml6YXRpb25zIiw1XQ==",
+            name: "Cyberdyne Systems",
+          },
+          {
+            __typename: "Person",
+            id: "WyJwZW9wbGUiLDFd",
+            username: "Alice",
+          },
+          {
+            __typename: "Person",
+            id: "WyJwZW9wbGUiLDJd",
+            username: "Benjie",
+          },
+        ],
+      },
+      {
+        id: "WyJmaXJzdF9wYXJ0eV92dWxuZXJhYmlsaXRpZXMiLDJd",
+        name: "Index-out-of-bounds",
+        applications: {
+          nodes: [
+            {
+              id: "WyJnY3BfYXBwbGljYXRpb25zIiwxXQ==",
+              name: "GCP App 1",
+              owner: {
+                __typename: "Organization",
+                id: "WyJvcmdhbml6YXRpb25zIiwxXQ==",
+                name: "Acme",
+              },
+            },
+            {
+              id: "WyJnY3BfYXBwbGljYXRpb25zIiwyXQ==",
+              name: "Grand Crayon Pasta",
+              owner: {
+                __typename: "Person",
+                id: "WyJwZW9wbGUiLDNd",
+                username: "Caroline",
+              },
+            },
+            {
+              id: "WyJnY3BfYXBwbGljYXRpb25zIiwzXQ==",
+              name: "Great Creative Project",
+              owner: {
+                __typename: "Person",
+                id: "WyJwZW9wbGUiLDJd",
+                username: "Benjie",
+              },
+            },
+          ],
+        },
+        applicationsList: [
+          {
+            id: "WyJnY3BfYXBwbGljYXRpb25zIiwxXQ==",
+            name: "GCP App 1",
+            owner: {
+              __typename: "Organization",
+              id: "WyJvcmdhbml6YXRpb25zIiwxXQ==",
+              name: "Acme",
+            },
+          },
+          {
+            id: "WyJnY3BfYXBwbGljYXRpb25zIiwyXQ==",
+            name: "Grand Crayon Pasta",
+            owner: {
+              __typename: "Person",
+              id: "WyJwZW9wbGUiLDNd",
+              username: "Caroline",
+            },
+          },
+          {
+            id: "WyJnY3BfYXBwbGljYXRpb25zIiwzXQ==",
+            name: "Great Creative Project",
+            owner: {
+              __typename: "Person",
+              id: "WyJwZW9wbGUiLDJd",
+              username: "Benjie",
+            },
+          },
+        ],
+        owners: {
+          nodes: [
+            {
+              __typename: "Organization",
+              id: "WyJvcmdhbml6YXRpb25zIiwxXQ==",
+              name: "Acme",
+            },
+            {
+              __typename: "Person",
+              id: "WyJwZW9wbGUiLDJd",
+              username: "Benjie",
+            },
+            {
+              __typename: "Person",
+              id: "WyJwZW9wbGUiLDNd",
+              username: "Caroline",
+            },
+          ],
+        },
+        ownersList: [
+          {
+            __typename: "Organization",
+            id: "WyJvcmdhbml6YXRpb25zIiwxXQ==",
+            name: "Acme",
+          },
+          {
+            __typename: "Person",
+            id: "WyJwZW9wbGUiLDJd",
+            username: "Benjie",
+          },
+          {
+            __typename: "Person",
+            id: "WyJwZW9wbGUiLDNd",
+            username: "Caroline",
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.mermaid
@@ -1,0 +1,946 @@
+%%{init: {'themeVariables': { 'fontSize': '12px'}}}%%
+graph TD
+    classDef path fill:#eee,stroke:#000,color:#000
+    classDef plan fill:#fff,stroke-width:1px,color:#000
+    classDef itemplan fill:#fff,stroke-width:2px,color:#000
+    classDef unbatchedplan fill:#dff,stroke-width:1px,color:#000
+    classDef sideeffectplan fill:#fcc,stroke-width:2px,color:#000
+    classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
+
+
+    %% plan dependencies
+    Object17{{"Object[17∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access15{{"Access[15∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access16{{"Access[16∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access15 & Access16 --> Object17
+    __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
+    __Value3 --> Access15
+    __Value3 --> Access16
+    Connection18{{"Connection[18∈0]<br />ᐸ14ᐳ"}}:::plan
+    Constant664{{"Constant[664∈0]<br />ᐸ2ᐳ"}}:::plan
+    Constant664 --> Connection18
+    __Value0["__Value[0∈0]"]:::plan
+    __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
+    PgUnionAll19[["PgUnionAll[19∈1]"]]:::plan
+    Object17 & Connection18 --> PgUnionAll19
+    __Item20[/"__Item[20∈2]<br />ᐸ19ᐳ"\]:::itemplan
+    PgUnionAll19 ==> __Item20
+    PgUnionAllSingle21["PgUnionAllSingle[21∈2]"]:::plan
+    __Item20 --> PgUnionAllSingle21
+    Access22{{"Access[22∈2]<br />ᐸ21.1ᐳ"}}:::plan
+    PgUnionAllSingle21 --> Access22
+    PgUnionAll274[["PgUnionAll[274∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
+    PgClassExpression32{{"PgClassExpression[32∈3]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
+    Connection273{{"Connection[273∈3]<br />ᐸ269ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
+    Object17 & PgClassExpression32 & PgClassExpression32 & PgClassExpression32 & PgClassExpression32 & Connection273 --> PgUnionAll274
+    PgUnionAll595[["PgUnionAll[595∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
+    PgClassExpression353{{"PgClassExpression[353∈3]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
+    Connection594{{"Connection[594∈3]<br />ᐸ590ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
+    Object17 & PgClassExpression353 & PgClassExpression353 & PgClassExpression353 & PgClassExpression353 & Connection594 --> PgUnionAll595
+    PgUnionAll309[["PgUnionAll[309∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
+    Object17 & PgClassExpression32 & PgClassExpression32 & PgClassExpression32 & PgClassExpression32 --> PgUnionAll309
+    PgUnionAll630[["PgUnionAll[630∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
+    Object17 & PgClassExpression353 & PgClassExpression353 & PgClassExpression353 & PgClassExpression353 --> PgUnionAll630
+    PgUnionAll50[["PgUnionAll[50∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
+    Connection49{{"Connection[49∈3]<br />ᐸ45ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
+    Object17 & PgClassExpression32 & PgClassExpression32 & Connection49 --> PgUnionAll50
+    PgUnionAll371[["PgUnionAll[371∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
+    Connection370{{"Connection[370∈3]<br />ᐸ366ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
+    Object17 & PgClassExpression353 & PgClassExpression353 & Connection370 --> PgUnionAll371
+    PgUnionAll159[["PgUnionAll[159∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
+    Object17 & PgClassExpression32 & PgClassExpression32 --> PgUnionAll159
+    PgUnionAll480[["PgUnionAll[480∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
+    Object17 & PgClassExpression353 & PgClassExpression353 --> PgUnionAll480
+    PgSelect25[["PgSelect[25∈3]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
+    Access24{{"Access[24∈3]<br />ᐸ23.0ᐳ"}}:::plan
+    Object17 & Access24 --> PgSelect25
+    List33{{"List[33∈3]<br />ᐸ31,32ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
+    Constant31{{"Constant[31∈3]<br />ᐸ'first_party_vulnerabilities'ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
+    Constant31 & PgClassExpression32 --> List33
+    PgSelect346[["PgSelect[346∈3]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
+    Access345{{"Access[345∈3]<br />ᐸ344.0ᐳ"}}:::plan
+    Object17 & Access345 --> PgSelect346
+    List354{{"List[354∈3]<br />ᐸ352,353ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
+    Constant352{{"Constant[352∈3]<br />ᐸ'third_party_vulnerabilities'ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
+    Constant352 & PgClassExpression353 --> List354
+    JSONParse23[["JSONParse[23∈3]<br />ᐸ22ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
+    Access22 --> JSONParse23
+    JSONParse23 --> Access24
+    First29{{"First[29∈3]"}}:::plan
+    PgSelect25 --> First29
+    PgSelectSingle30{{"PgSelectSingle[30∈3]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
+    First29 --> PgSelectSingle30
+    PgSelectSingle30 --> PgClassExpression32
+    Lambda34{{"Lambda[34∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List33 --> Lambda34
+    PgClassExpression35{{"PgClassExpression[35∈3]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle30 --> PgClassExpression35
+    JSONParse344[["JSONParse[344∈3]<br />ᐸ22ᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
+    Access22 --> JSONParse344
+    JSONParse344 --> Access345
+    First350{{"First[350∈3]"}}:::plan
+    PgSelect346 --> First350
+    PgSelectSingle351{{"PgSelectSingle[351∈3]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
+    First350 --> PgSelectSingle351
+    PgSelectSingle351 --> PgClassExpression353
+    Lambda355{{"Lambda[355∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List354 --> Lambda355
+    PgClassExpression356{{"PgClassExpression[356∈3]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle351 --> PgClassExpression356
+    __Item634[/"__Item[634∈26]<br />ᐸ630ᐳ"\]:::itemplan
+    PgUnionAll630 ==> __Item634
+    PgUnionAllSingle635["PgUnionAllSingle[635∈26]"]:::plan
+    __Item634 --> PgUnionAllSingle635
+    Access636{{"Access[636∈26]<br />ᐸ635.1ᐳ"}}:::plan
+    PgUnionAllSingle635 --> Access636
+    __Item596[/"__Item[596∈24]<br />ᐸ595ᐳ"\]:::itemplan
+    PgUnionAll595 ==> __Item596
+    PgUnionAllSingle597["PgUnionAllSingle[597∈24]"]:::plan
+    __Item596 --> PgUnionAllSingle597
+    Access598{{"Access[598∈24]<br />ᐸ597.1ᐳ"}}:::plan
+    PgUnionAllSingle597 --> Access598
+    __Item484[/"__Item[484∈20]<br />ᐸ480ᐳ"\]:::itemplan
+    PgUnionAll480 ==> __Item484
+    PgUnionAllSingle485["PgUnionAllSingle[485∈20]"]:::plan
+    __Item484 --> PgUnionAllSingle485
+    Access486{{"Access[486∈20]<br />ᐸ485.1ᐳ"}}:::plan
+    PgUnionAllSingle485 --> Access486
+    __Item372[/"__Item[372∈16]<br />ᐸ371ᐳ"\]:::itemplan
+    PgUnionAll371 ==> __Item372
+    PgUnionAllSingle373["PgUnionAllSingle[373∈16]"]:::plan
+    __Item372 --> PgUnionAllSingle373
+    Access374{{"Access[374∈16]<br />ᐸ373.1ᐳ"}}:::plan
+    PgUnionAllSingle373 --> Access374
+    __Item313[/"__Item[313∈14]<br />ᐸ309ᐳ"\]:::itemplan
+    PgUnionAll309 ==> __Item313
+    PgUnionAllSingle314["PgUnionAllSingle[314∈14]"]:::plan
+    __Item313 --> PgUnionAllSingle314
+    Access315{{"Access[315∈14]<br />ᐸ314.1ᐳ"}}:::plan
+    PgUnionAllSingle314 --> Access315
+    __Item275[/"__Item[275∈12]<br />ᐸ274ᐳ"\]:::itemplan
+    PgUnionAll274 ==> __Item275
+    PgUnionAllSingle276["PgUnionAllSingle[276∈12]"]:::plan
+    __Item275 --> PgUnionAllSingle276
+    Access277{{"Access[277∈12]<br />ᐸ276.1ᐳ"}}:::plan
+    PgUnionAllSingle276 --> Access277
+    __Item163[/"__Item[163∈8]<br />ᐸ159ᐳ"\]:::itemplan
+    PgUnionAll159 ==> __Item163
+    PgUnionAllSingle164["PgUnionAllSingle[164∈8]"]:::plan
+    __Item163 --> PgUnionAllSingle164
+    Access165{{"Access[165∈8]<br />ᐸ164.1ᐳ"}}:::plan
+    PgUnionAllSingle164 --> Access165
+    __Item51[/"__Item[51∈4]<br />ᐸ50ᐳ"\]:::itemplan
+    PgUnionAll50 ==> __Item51
+    PgUnionAllSingle52["PgUnionAllSingle[52∈4]"]:::plan
+    __Item51 --> PgUnionAllSingle52
+    Access53{{"Access[53∈4]<br />ᐸ52.1ᐳ"}}:::plan
+    PgUnionAllSingle52 --> Access53
+    PgUnionAll69[["PgUnionAll[69∈5]<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
+    PgClassExpression67{{"PgClassExpression[67∈5]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression68{{"PgClassExpression[68∈5]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
+    Object17 & PgClassExpression67 & PgClassExpression68 --> PgUnionAll69
+    PgUnionAll119[["PgUnionAll[119∈5]<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
+    PgClassExpression117{{"PgClassExpression[117∈5]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression118{{"PgClassExpression[118∈5]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
+    Object17 & PgClassExpression117 & PgClassExpression118 --> PgUnionAll119
+    PgUnionAll181[["PgUnionAll[181∈9]<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
+    PgClassExpression179{{"PgClassExpression[179∈9]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression180{{"PgClassExpression[180∈9]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
+    Object17 & PgClassExpression179 & PgClassExpression180 --> PgUnionAll181
+    PgUnionAll231[["PgUnionAll[231∈9]<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
+    PgClassExpression229{{"PgClassExpression[229∈9]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression230{{"PgClassExpression[230∈9]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
+    Object17 & PgClassExpression229 & PgClassExpression230 --> PgUnionAll231
+    PgUnionAll390[["PgUnionAll[390∈17]<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
+    PgClassExpression388{{"PgClassExpression[388∈17]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression389{{"PgClassExpression[389∈17]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
+    Object17 & PgClassExpression388 & PgClassExpression389 --> PgUnionAll390
+    PgUnionAll440[["PgUnionAll[440∈17]<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
+    PgClassExpression438{{"PgClassExpression[438∈17]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression439{{"PgClassExpression[439∈17]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
+    Object17 & PgClassExpression438 & PgClassExpression439 --> PgUnionAll440
+    PgUnionAll502[["PgUnionAll[502∈21]<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
+    PgClassExpression500{{"PgClassExpression[500∈21]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression501{{"PgClassExpression[501∈21]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
+    Object17 & PgClassExpression500 & PgClassExpression501 --> PgUnionAll502
+    PgUnionAll552[["PgUnionAll[552∈21]<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
+    PgClassExpression550{{"PgClassExpression[550∈21]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression551{{"PgClassExpression[551∈21]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
+    Object17 & PgClassExpression550 & PgClassExpression551 --> PgUnionAll552
+    PgSelect56[["PgSelect[56∈5]<br />ᐸaws_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
+    Access55{{"Access[55∈5]<br />ᐸ54.0ᐳ"}}:::plan
+    Object17 & Access55 --> PgSelect56
+    List64{{"List[64∈5]<br />ᐸ62,63ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"}}:::plan
+    Constant62{{"Constant[62∈5]<br />ᐸ'aws_applications'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"}}:::plan
+    PgClassExpression63{{"PgClassExpression[63∈5]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
+    Constant62 & PgClassExpression63 --> List64
+    PgSelect106[["PgSelect[106∈5]<br />ᐸgcp_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access105{{"Access[105∈5]<br />ᐸ104.0ᐳ"}}:::plan
+    Object17 & Access105 --> PgSelect106
+    List114{{"List[114∈5]<br />ᐸ112,113ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"}}:::plan
+    Constant112{{"Constant[112∈5]<br />ᐸ'gcp_applications'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"}}:::plan
+    PgClassExpression113{{"PgClassExpression[113∈5]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
+    Constant112 & PgClassExpression113 --> List114
+    PgSelect168[["PgSelect[168∈9]<br />ᐸaws_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
+    Access167{{"Access[167∈9]<br />ᐸ166.0ᐳ"}}:::plan
+    Object17 & Access167 --> PgSelect168
+    List176{{"List[176∈9]<br />ᐸ174,175ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"}}:::plan
+    Constant174{{"Constant[174∈9]<br />ᐸ'aws_applications'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"}}:::plan
+    PgClassExpression175{{"PgClassExpression[175∈9]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
+    Constant174 & PgClassExpression175 --> List176
+    PgSelect218[["PgSelect[218∈9]<br />ᐸgcp_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access217{{"Access[217∈9]<br />ᐸ216.0ᐳ"}}:::plan
+    Object17 & Access217 --> PgSelect218
+    List226{{"List[226∈9]<br />ᐸ224,225ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"}}:::plan
+    Constant224{{"Constant[224∈9]<br />ᐸ'gcp_applications'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"}}:::plan
+    PgClassExpression225{{"PgClassExpression[225∈9]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
+    Constant224 & PgClassExpression225 --> List226
+    PgSelect280[["PgSelect[280∈13]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
+    Access279{{"Access[279∈13]<br />ᐸ278.0ᐳ"}}:::plan
+    Object17 & Access279 --> PgSelect280
+    List288{{"List[288∈13]<br />ᐸ286,287ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
+    Constant286{{"Constant[286∈13]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
+    PgClassExpression287{{"PgClassExpression[287∈13]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant286 & PgClassExpression287 --> List288
+    PgSelect294[["PgSelect[294∈13]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
+    Access293{{"Access[293∈13]<br />ᐸ292.0ᐳ"}}:::plan
+    Object17 & Access293 --> PgSelect294
+    List302{{"List[302∈13]<br />ᐸ300,301ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
+    Constant300{{"Constant[300∈13]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
+    PgClassExpression301{{"PgClassExpression[301∈13]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant300 & PgClassExpression301 --> List302
+    PgSelect318[["PgSelect[318∈15]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
+    Access317{{"Access[317∈15]<br />ᐸ316.0ᐳ"}}:::plan
+    Object17 & Access317 --> PgSelect318
+    List326{{"List[326∈15]<br />ᐸ324,325ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
+    Constant324{{"Constant[324∈15]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
+    PgClassExpression325{{"PgClassExpression[325∈15]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant324 & PgClassExpression325 --> List326
+    PgSelect332[["PgSelect[332∈15]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
+    Access331{{"Access[331∈15]<br />ᐸ330.0ᐳ"}}:::plan
+    Object17 & Access331 --> PgSelect332
+    List340{{"List[340∈15]<br />ᐸ338,339ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
+    Constant338{{"Constant[338∈15]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
+    PgClassExpression339{{"PgClassExpression[339∈15]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant338 & PgClassExpression339 --> List340
+    PgSelect377[["PgSelect[377∈17]<br />ᐸaws_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
+    Access376{{"Access[376∈17]<br />ᐸ375.0ᐳ"}}:::plan
+    Object17 & Access376 --> PgSelect377
+    List385{{"List[385∈17]<br />ᐸ383,384ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"}}:::plan
+    Constant383{{"Constant[383∈17]<br />ᐸ'aws_applications'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"}}:::plan
+    PgClassExpression384{{"PgClassExpression[384∈17]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
+    Constant383 & PgClassExpression384 --> List385
+    PgSelect427[["PgSelect[427∈17]<br />ᐸgcp_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access426{{"Access[426∈17]<br />ᐸ425.0ᐳ"}}:::plan
+    Object17 & Access426 --> PgSelect427
+    List435{{"List[435∈17]<br />ᐸ433,434ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"}}:::plan
+    Constant433{{"Constant[433∈17]<br />ᐸ'gcp_applications'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"}}:::plan
+    PgClassExpression434{{"PgClassExpression[434∈17]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
+    Constant433 & PgClassExpression434 --> List435
+    PgSelect489[["PgSelect[489∈21]<br />ᐸaws_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
+    Access488{{"Access[488∈21]<br />ᐸ487.0ᐳ"}}:::plan
+    Object17 & Access488 --> PgSelect489
+    List497{{"List[497∈21]<br />ᐸ495,496ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"}}:::plan
+    Constant495{{"Constant[495∈21]<br />ᐸ'aws_applications'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"}}:::plan
+    PgClassExpression496{{"PgClassExpression[496∈21]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
+    Constant495 & PgClassExpression496 --> List497
+    PgSelect539[["PgSelect[539∈21]<br />ᐸgcp_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access538{{"Access[538∈21]<br />ᐸ537.0ᐳ"}}:::plan
+    Object17 & Access538 --> PgSelect539
+    List547{{"List[547∈21]<br />ᐸ545,546ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"}}:::plan
+    Constant545{{"Constant[545∈21]<br />ᐸ'gcp_applications'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"}}:::plan
+    PgClassExpression546{{"PgClassExpression[546∈21]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
+    Constant545 & PgClassExpression546 --> List547
+    PgSelect601[["PgSelect[601∈25]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
+    Access600{{"Access[600∈25]<br />ᐸ599.0ᐳ"}}:::plan
+    Object17 & Access600 --> PgSelect601
+    List609{{"List[609∈25]<br />ᐸ607,608ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
+    Constant607{{"Constant[607∈25]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
+    PgClassExpression608{{"PgClassExpression[608∈25]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant607 & PgClassExpression608 --> List609
+    PgSelect615[["PgSelect[615∈25]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
+    Access614{{"Access[614∈25]<br />ᐸ613.0ᐳ"}}:::plan
+    Object17 & Access614 --> PgSelect615
+    List623{{"List[623∈25]<br />ᐸ621,622ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
+    Constant621{{"Constant[621∈25]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
+    PgClassExpression622{{"PgClassExpression[622∈25]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant621 & PgClassExpression622 --> List623
+    PgSelect639[["PgSelect[639∈27]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
+    Access638{{"Access[638∈27]<br />ᐸ637.0ᐳ"}}:::plan
+    Object17 & Access638 --> PgSelect639
+    List647{{"List[647∈27]<br />ᐸ645,646ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
+    Constant645{{"Constant[645∈27]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
+    PgClassExpression646{{"PgClassExpression[646∈27]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant645 & PgClassExpression646 --> List647
+    PgSelect653[["PgSelect[653∈27]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
+    Access652{{"Access[652∈27]<br />ᐸ651.0ᐳ"}}:::plan
+    Object17 & Access652 --> PgSelect653
+    List661{{"List[661∈27]<br />ᐸ659,660ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
+    Constant659{{"Constant[659∈27]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
+    PgClassExpression660{{"PgClassExpression[660∈27]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant659 & PgClassExpression660 --> List661
+    JSONParse54[["JSONParse[54∈5]<br />ᐸ53ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
+    Access53 --> JSONParse54
+    JSONParse54 --> Access55
+    First60{{"First[60∈5]"}}:::plan
+    PgSelect56 --> First60
+    PgSelectSingle61{{"PgSelectSingle[61∈5]<br />ᐸaws_applicationsᐳ"}}:::plan
+    First60 --> PgSelectSingle61
+    PgSelectSingle61 --> PgClassExpression63
+    Lambda65{{"Lambda[65∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List64 --> Lambda65
+    PgClassExpression66{{"PgClassExpression[66∈5]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle61 --> PgClassExpression66
+    PgSelectSingle61 --> PgClassExpression67
+    PgSelectSingle61 --> PgClassExpression68
+    First73{{"First[73∈5]"}}:::plan
+    PgUnionAll69 --> First73
+    PgUnionAllSingle74["PgUnionAllSingle[74∈5]"]:::plan
+    First73 --> PgUnionAllSingle74
+    Access75{{"Access[75∈5]<br />ᐸ74.1ᐳ"}}:::plan
+    PgUnionAllSingle74 --> Access75
+    JSONParse104[["JSONParse[104∈5]<br />ᐸ53ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access53 --> JSONParse104
+    JSONParse104 --> Access105
+    First110{{"First[110∈5]"}}:::plan
+    PgSelect106 --> First110
+    PgSelectSingle111{{"PgSelectSingle[111∈5]<br />ᐸgcp_applicationsᐳ"}}:::plan
+    First110 --> PgSelectSingle111
+    PgSelectSingle111 --> PgClassExpression113
+    Lambda115{{"Lambda[115∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List114 --> Lambda115
+    PgClassExpression116{{"PgClassExpression[116∈5]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle111 --> PgClassExpression116
+    PgSelectSingle111 --> PgClassExpression117
+    PgSelectSingle111 --> PgClassExpression118
+    First123{{"First[123∈5]"}}:::plan
+    PgUnionAll119 --> First123
+    PgUnionAllSingle124["PgUnionAllSingle[124∈5]"]:::plan
+    First123 --> PgUnionAllSingle124
+    Access125{{"Access[125∈5]<br />ᐸ124.1ᐳ"}}:::plan
+    PgUnionAllSingle124 --> Access125
+    JSONParse166[["JSONParse[166∈9]<br />ᐸ165ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
+    Access165 --> JSONParse166
+    JSONParse166 --> Access167
+    First172{{"First[172∈9]"}}:::plan
+    PgSelect168 --> First172
+    PgSelectSingle173{{"PgSelectSingle[173∈9]<br />ᐸaws_applicationsᐳ"}}:::plan
+    First172 --> PgSelectSingle173
+    PgSelectSingle173 --> PgClassExpression175
+    Lambda177{{"Lambda[177∈9]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List176 --> Lambda177
+    PgClassExpression178{{"PgClassExpression[178∈9]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle173 --> PgClassExpression178
+    PgSelectSingle173 --> PgClassExpression179
+    PgSelectSingle173 --> PgClassExpression180
+    First185{{"First[185∈9]"}}:::plan
+    PgUnionAll181 --> First185
+    PgUnionAllSingle186["PgUnionAllSingle[186∈9]"]:::plan
+    First185 --> PgUnionAllSingle186
+    Access187{{"Access[187∈9]<br />ᐸ186.1ᐳ"}}:::plan
+    PgUnionAllSingle186 --> Access187
+    JSONParse216[["JSONParse[216∈9]<br />ᐸ165ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access165 --> JSONParse216
+    JSONParse216 --> Access217
+    First222{{"First[222∈9]"}}:::plan
+    PgSelect218 --> First222
+    PgSelectSingle223{{"PgSelectSingle[223∈9]<br />ᐸgcp_applicationsᐳ"}}:::plan
+    First222 --> PgSelectSingle223
+    PgSelectSingle223 --> PgClassExpression225
+    Lambda227{{"Lambda[227∈9]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List226 --> Lambda227
+    PgClassExpression228{{"PgClassExpression[228∈9]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle223 --> PgClassExpression228
+    PgSelectSingle223 --> PgClassExpression229
+    PgSelectSingle223 --> PgClassExpression230
+    First235{{"First[235∈9]"}}:::plan
+    PgUnionAll231 --> First235
+    PgUnionAllSingle236["PgUnionAllSingle[236∈9]"]:::plan
+    First235 --> PgUnionAllSingle236
+    Access237{{"Access[237∈9]<br />ᐸ236.1ᐳ"}}:::plan
+    PgUnionAllSingle236 --> Access237
+    JSONParse278[["JSONParse[278∈13]<br />ᐸ277ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
+    Access277 --> JSONParse278
+    JSONParse278 --> Access279
+    First284{{"First[284∈13]"}}:::plan
+    PgSelect280 --> First284
+    PgSelectSingle285{{"PgSelectSingle[285∈13]<br />ᐸorganizationsᐳ"}}:::plan
+    First284 --> PgSelectSingle285
+    PgSelectSingle285 --> PgClassExpression287
+    Lambda289{{"Lambda[289∈13]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List288 --> Lambda289
+    PgClassExpression290{{"PgClassExpression[290∈13]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle285 --> PgClassExpression290
+    JSONParse292[["JSONParse[292∈13]<br />ᐸ277ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
+    Access277 --> JSONParse292
+    JSONParse292 --> Access293
+    First298{{"First[298∈13]"}}:::plan
+    PgSelect294 --> First298
+    PgSelectSingle299{{"PgSelectSingle[299∈13]<br />ᐸpeopleᐳ"}}:::plan
+    First298 --> PgSelectSingle299
+    PgSelectSingle299 --> PgClassExpression301
+    Lambda303{{"Lambda[303∈13]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List302 --> Lambda303
+    PgClassExpression304{{"PgClassExpression[304∈13]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle299 --> PgClassExpression304
+    JSONParse316[["JSONParse[316∈15]<br />ᐸ315ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
+    Access315 --> JSONParse316
+    JSONParse316 --> Access317
+    First322{{"First[322∈15]"}}:::plan
+    PgSelect318 --> First322
+    PgSelectSingle323{{"PgSelectSingle[323∈15]<br />ᐸorganizationsᐳ"}}:::plan
+    First322 --> PgSelectSingle323
+    PgSelectSingle323 --> PgClassExpression325
+    Lambda327{{"Lambda[327∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List326 --> Lambda327
+    PgClassExpression328{{"PgClassExpression[328∈15]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle323 --> PgClassExpression328
+    JSONParse330[["JSONParse[330∈15]<br />ᐸ315ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
+    Access315 --> JSONParse330
+    JSONParse330 --> Access331
+    First336{{"First[336∈15]"}}:::plan
+    PgSelect332 --> First336
+    PgSelectSingle337{{"PgSelectSingle[337∈15]<br />ᐸpeopleᐳ"}}:::plan
+    First336 --> PgSelectSingle337
+    PgSelectSingle337 --> PgClassExpression339
+    Lambda341{{"Lambda[341∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List340 --> Lambda341
+    PgClassExpression342{{"PgClassExpression[342∈15]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle337 --> PgClassExpression342
+    JSONParse375[["JSONParse[375∈17]<br />ᐸ374ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
+    Access374 --> JSONParse375
+    JSONParse375 --> Access376
+    First381{{"First[381∈17]"}}:::plan
+    PgSelect377 --> First381
+    PgSelectSingle382{{"PgSelectSingle[382∈17]<br />ᐸaws_applicationsᐳ"}}:::plan
+    First381 --> PgSelectSingle382
+    PgSelectSingle382 --> PgClassExpression384
+    Lambda386{{"Lambda[386∈17]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List385 --> Lambda386
+    PgClassExpression387{{"PgClassExpression[387∈17]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle382 --> PgClassExpression387
+    PgSelectSingle382 --> PgClassExpression388
+    PgSelectSingle382 --> PgClassExpression389
+    First394{{"First[394∈17]"}}:::plan
+    PgUnionAll390 --> First394
+    PgUnionAllSingle395["PgUnionAllSingle[395∈17]"]:::plan
+    First394 --> PgUnionAllSingle395
+    Access396{{"Access[396∈17]<br />ᐸ395.1ᐳ"}}:::plan
+    PgUnionAllSingle395 --> Access396
+    JSONParse425[["JSONParse[425∈17]<br />ᐸ374ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access374 --> JSONParse425
+    JSONParse425 --> Access426
+    First431{{"First[431∈17]"}}:::plan
+    PgSelect427 --> First431
+    PgSelectSingle432{{"PgSelectSingle[432∈17]<br />ᐸgcp_applicationsᐳ"}}:::plan
+    First431 --> PgSelectSingle432
+    PgSelectSingle432 --> PgClassExpression434
+    Lambda436{{"Lambda[436∈17]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List435 --> Lambda436
+    PgClassExpression437{{"PgClassExpression[437∈17]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle432 --> PgClassExpression437
+    PgSelectSingle432 --> PgClassExpression438
+    PgSelectSingle432 --> PgClassExpression439
+    First444{{"First[444∈17]"}}:::plan
+    PgUnionAll440 --> First444
+    PgUnionAllSingle445["PgUnionAllSingle[445∈17]"]:::plan
+    First444 --> PgUnionAllSingle445
+    Access446{{"Access[446∈17]<br />ᐸ445.1ᐳ"}}:::plan
+    PgUnionAllSingle445 --> Access446
+    JSONParse487[["JSONParse[487∈21]<br />ᐸ486ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
+    Access486 --> JSONParse487
+    JSONParse487 --> Access488
+    First493{{"First[493∈21]"}}:::plan
+    PgSelect489 --> First493
+    PgSelectSingle494{{"PgSelectSingle[494∈21]<br />ᐸaws_applicationsᐳ"}}:::plan
+    First493 --> PgSelectSingle494
+    PgSelectSingle494 --> PgClassExpression496
+    Lambda498{{"Lambda[498∈21]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List497 --> Lambda498
+    PgClassExpression499{{"PgClassExpression[499∈21]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle494 --> PgClassExpression499
+    PgSelectSingle494 --> PgClassExpression500
+    PgSelectSingle494 --> PgClassExpression501
+    First506{{"First[506∈21]"}}:::plan
+    PgUnionAll502 --> First506
+    PgUnionAllSingle507["PgUnionAllSingle[507∈21]"]:::plan
+    First506 --> PgUnionAllSingle507
+    Access508{{"Access[508∈21]<br />ᐸ507.1ᐳ"}}:::plan
+    PgUnionAllSingle507 --> Access508
+    JSONParse537[["JSONParse[537∈21]<br />ᐸ486ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access486 --> JSONParse537
+    JSONParse537 --> Access538
+    First543{{"First[543∈21]"}}:::plan
+    PgSelect539 --> First543
+    PgSelectSingle544{{"PgSelectSingle[544∈21]<br />ᐸgcp_applicationsᐳ"}}:::plan
+    First543 --> PgSelectSingle544
+    PgSelectSingle544 --> PgClassExpression546
+    Lambda548{{"Lambda[548∈21]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List547 --> Lambda548
+    PgClassExpression549{{"PgClassExpression[549∈21]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle544 --> PgClassExpression549
+    PgSelectSingle544 --> PgClassExpression550
+    PgSelectSingle544 --> PgClassExpression551
+    First556{{"First[556∈21]"}}:::plan
+    PgUnionAll552 --> First556
+    PgUnionAllSingle557["PgUnionAllSingle[557∈21]"]:::plan
+    First556 --> PgUnionAllSingle557
+    Access558{{"Access[558∈21]<br />ᐸ557.1ᐳ"}}:::plan
+    PgUnionAllSingle557 --> Access558
+    JSONParse599[["JSONParse[599∈25]<br />ᐸ598ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
+    Access598 --> JSONParse599
+    JSONParse599 --> Access600
+    First605{{"First[605∈25]"}}:::plan
+    PgSelect601 --> First605
+    PgSelectSingle606{{"PgSelectSingle[606∈25]<br />ᐸorganizationsᐳ"}}:::plan
+    First605 --> PgSelectSingle606
+    PgSelectSingle606 --> PgClassExpression608
+    Lambda610{{"Lambda[610∈25]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List609 --> Lambda610
+    PgClassExpression611{{"PgClassExpression[611∈25]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle606 --> PgClassExpression611
+    JSONParse613[["JSONParse[613∈25]<br />ᐸ598ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
+    Access598 --> JSONParse613
+    JSONParse613 --> Access614
+    First619{{"First[619∈25]"}}:::plan
+    PgSelect615 --> First619
+    PgSelectSingle620{{"PgSelectSingle[620∈25]<br />ᐸpeopleᐳ"}}:::plan
+    First619 --> PgSelectSingle620
+    PgSelectSingle620 --> PgClassExpression622
+    Lambda624{{"Lambda[624∈25]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List623 --> Lambda624
+    PgClassExpression625{{"PgClassExpression[625∈25]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle620 --> PgClassExpression625
+    JSONParse637[["JSONParse[637∈27]<br />ᐸ636ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
+    Access636 --> JSONParse637
+    JSONParse637 --> Access638
+    First643{{"First[643∈27]"}}:::plan
+    PgSelect639 --> First643
+    PgSelectSingle644{{"PgSelectSingle[644∈27]<br />ᐸorganizationsᐳ"}}:::plan
+    First643 --> PgSelectSingle644
+    PgSelectSingle644 --> PgClassExpression646
+    Lambda648{{"Lambda[648∈27]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List647 --> Lambda648
+    PgClassExpression649{{"PgClassExpression[649∈27]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle644 --> PgClassExpression649
+    JSONParse651[["JSONParse[651∈27]<br />ᐸ636ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
+    Access636 --> JSONParse651
+    JSONParse651 --> Access652
+    First657{{"First[657∈27]"}}:::plan
+    PgSelect653 --> First657
+    PgSelectSingle658{{"PgSelectSingle[658∈27]<br />ᐸpeopleᐳ"}}:::plan
+    First657 --> PgSelectSingle658
+    PgSelectSingle658 --> PgClassExpression660
+    Lambda662{{"Lambda[662∈27]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List661 --> Lambda662
+    PgClassExpression663{{"PgClassExpression[663∈27]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle658 --> PgClassExpression663
+    PgSelect128[["PgSelect[128∈7]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
+    Access127{{"Access[127∈7]<br />ᐸ126.0ᐳ"}}:::plan
+    Object17 & Access127 --> PgSelect128
+    List136{{"List[136∈7]<br />ᐸ134,135ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
+    Constant134{{"Constant[134∈7]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
+    PgClassExpression135{{"PgClassExpression[135∈7]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant134 & PgClassExpression135 --> List136
+    PgSelect142[["PgSelect[142∈7]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
+    Access141{{"Access[141∈7]<br />ᐸ140.0ᐳ"}}:::plan
+    Object17 & Access141 --> PgSelect142
+    List150{{"List[150∈7]<br />ᐸ148,149ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
+    Constant148{{"Constant[148∈7]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
+    PgClassExpression149{{"PgClassExpression[149∈7]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant148 & PgClassExpression149 --> List150
+    PgSelect240[["PgSelect[240∈11]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
+    Access239{{"Access[239∈11]<br />ᐸ238.0ᐳ"}}:::plan
+    Object17 & Access239 --> PgSelect240
+    List248{{"List[248∈11]<br />ᐸ246,247ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
+    Constant246{{"Constant[246∈11]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
+    PgClassExpression247{{"PgClassExpression[247∈11]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant246 & PgClassExpression247 --> List248
+    PgSelect254[["PgSelect[254∈11]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
+    Access253{{"Access[253∈11]<br />ᐸ252.0ᐳ"}}:::plan
+    Object17 & Access253 --> PgSelect254
+    List262{{"List[262∈11]<br />ᐸ260,261ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
+    Constant260{{"Constant[260∈11]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
+    PgClassExpression261{{"PgClassExpression[261∈11]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant260 & PgClassExpression261 --> List262
+    PgSelect449[["PgSelect[449∈19]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
+    Access448{{"Access[448∈19]<br />ᐸ447.0ᐳ"}}:::plan
+    Object17 & Access448 --> PgSelect449
+    List457{{"List[457∈19]<br />ᐸ455,456ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
+    Constant455{{"Constant[455∈19]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
+    PgClassExpression456{{"PgClassExpression[456∈19]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant455 & PgClassExpression456 --> List457
+    PgSelect463[["PgSelect[463∈19]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
+    Access462{{"Access[462∈19]<br />ᐸ461.0ᐳ"}}:::plan
+    Object17 & Access462 --> PgSelect463
+    List471{{"List[471∈19]<br />ᐸ469,470ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
+    Constant469{{"Constant[469∈19]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
+    PgClassExpression470{{"PgClassExpression[470∈19]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant469 & PgClassExpression470 --> List471
+    PgSelect561[["PgSelect[561∈23]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
+    Access560{{"Access[560∈23]<br />ᐸ559.0ᐳ"}}:::plan
+    Object17 & Access560 --> PgSelect561
+    List569{{"List[569∈23]<br />ᐸ567,568ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
+    Constant567{{"Constant[567∈23]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
+    PgClassExpression568{{"PgClassExpression[568∈23]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant567 & PgClassExpression568 --> List569
+    PgSelect575[["PgSelect[575∈23]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
+    Access574{{"Access[574∈23]<br />ᐸ573.0ᐳ"}}:::plan
+    Object17 & Access574 --> PgSelect575
+    List583{{"List[583∈23]<br />ᐸ581,582ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
+    Constant581{{"Constant[581∈23]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
+    PgClassExpression582{{"PgClassExpression[582∈23]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant581 & PgClassExpression582 --> List583
+    JSONParse126[["JSONParse[126∈7]<br />ᐸ125ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
+    Access125 --> JSONParse126
+    JSONParse126 --> Access127
+    First132{{"First[132∈7]"}}:::plan
+    PgSelect128 --> First132
+    PgSelectSingle133{{"PgSelectSingle[133∈7]<br />ᐸorganizationsᐳ"}}:::plan
+    First132 --> PgSelectSingle133
+    PgSelectSingle133 --> PgClassExpression135
+    Lambda137{{"Lambda[137∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List136 --> Lambda137
+    PgClassExpression138{{"PgClassExpression[138∈7]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle133 --> PgClassExpression138
+    JSONParse140[["JSONParse[140∈7]<br />ᐸ125ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
+    Access125 --> JSONParse140
+    JSONParse140 --> Access141
+    First146{{"First[146∈7]"}}:::plan
+    PgSelect142 --> First146
+    PgSelectSingle147{{"PgSelectSingle[147∈7]<br />ᐸpeopleᐳ"}}:::plan
+    First146 --> PgSelectSingle147
+    PgSelectSingle147 --> PgClassExpression149
+    Lambda151{{"Lambda[151∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List150 --> Lambda151
+    PgClassExpression152{{"PgClassExpression[152∈7]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle147 --> PgClassExpression152
+    JSONParse238[["JSONParse[238∈11]<br />ᐸ237ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
+    Access237 --> JSONParse238
+    JSONParse238 --> Access239
+    First244{{"First[244∈11]"}}:::plan
+    PgSelect240 --> First244
+    PgSelectSingle245{{"PgSelectSingle[245∈11]<br />ᐸorganizationsᐳ"}}:::plan
+    First244 --> PgSelectSingle245
+    PgSelectSingle245 --> PgClassExpression247
+    Lambda249{{"Lambda[249∈11]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List248 --> Lambda249
+    PgClassExpression250{{"PgClassExpression[250∈11]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle245 --> PgClassExpression250
+    JSONParse252[["JSONParse[252∈11]<br />ᐸ237ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
+    Access237 --> JSONParse252
+    JSONParse252 --> Access253
+    First258{{"First[258∈11]"}}:::plan
+    PgSelect254 --> First258
+    PgSelectSingle259{{"PgSelectSingle[259∈11]<br />ᐸpeopleᐳ"}}:::plan
+    First258 --> PgSelectSingle259
+    PgSelectSingle259 --> PgClassExpression261
+    Lambda263{{"Lambda[263∈11]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List262 --> Lambda263
+    PgClassExpression264{{"PgClassExpression[264∈11]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle259 --> PgClassExpression264
+    JSONParse447[["JSONParse[447∈19]<br />ᐸ446ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
+    Access446 --> JSONParse447
+    JSONParse447 --> Access448
+    First453{{"First[453∈19]"}}:::plan
+    PgSelect449 --> First453
+    PgSelectSingle454{{"PgSelectSingle[454∈19]<br />ᐸorganizationsᐳ"}}:::plan
+    First453 --> PgSelectSingle454
+    PgSelectSingle454 --> PgClassExpression456
+    Lambda458{{"Lambda[458∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List457 --> Lambda458
+    PgClassExpression459{{"PgClassExpression[459∈19]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle454 --> PgClassExpression459
+    JSONParse461[["JSONParse[461∈19]<br />ᐸ446ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
+    Access446 --> JSONParse461
+    JSONParse461 --> Access462
+    First467{{"First[467∈19]"}}:::plan
+    PgSelect463 --> First467
+    PgSelectSingle468{{"PgSelectSingle[468∈19]<br />ᐸpeopleᐳ"}}:::plan
+    First467 --> PgSelectSingle468
+    PgSelectSingle468 --> PgClassExpression470
+    Lambda472{{"Lambda[472∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List471 --> Lambda472
+    PgClassExpression473{{"PgClassExpression[473∈19]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle468 --> PgClassExpression473
+    JSONParse559[["JSONParse[559∈23]<br />ᐸ558ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
+    Access558 --> JSONParse559
+    JSONParse559 --> Access560
+    First565{{"First[565∈23]"}}:::plan
+    PgSelect561 --> First565
+    PgSelectSingle566{{"PgSelectSingle[566∈23]<br />ᐸorganizationsᐳ"}}:::plan
+    First565 --> PgSelectSingle566
+    PgSelectSingle566 --> PgClassExpression568
+    Lambda570{{"Lambda[570∈23]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List569 --> Lambda570
+    PgClassExpression571{{"PgClassExpression[571∈23]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle566 --> PgClassExpression571
+    JSONParse573[["JSONParse[573∈23]<br />ᐸ558ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
+    Access558 --> JSONParse573
+    JSONParse573 --> Access574
+    First579{{"First[579∈23]"}}:::plan
+    PgSelect575 --> First579
+    PgSelectSingle580{{"PgSelectSingle[580∈23]<br />ᐸpeopleᐳ"}}:::plan
+    First579 --> PgSelectSingle580
+    PgSelectSingle580 --> PgClassExpression582
+    Lambda584{{"Lambda[584∈23]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List583 --> Lambda584
+    PgClassExpression585{{"PgClassExpression[585∈23]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle580 --> PgClassExpression585
+    PgSelect78[["PgSelect[78∈6]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
+    Access77{{"Access[77∈6]<br />ᐸ76.0ᐳ"}}:::plan
+    Object17 & Access77 --> PgSelect78
+    List86{{"List[86∈6]<br />ᐸ84,85ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
+    Constant84{{"Constant[84∈6]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
+    PgClassExpression85{{"PgClassExpression[85∈6]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant84 & PgClassExpression85 --> List86
+    PgSelect92[["PgSelect[92∈6]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
+    Access91{{"Access[91∈6]<br />ᐸ90.0ᐳ"}}:::plan
+    Object17 & Access91 --> PgSelect92
+    List100{{"List[100∈6]<br />ᐸ98,99ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
+    Constant98{{"Constant[98∈6]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
+    PgClassExpression99{{"PgClassExpression[99∈6]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant98 & PgClassExpression99 --> List100
+    PgSelect190[["PgSelect[190∈10]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
+    Access189{{"Access[189∈10]<br />ᐸ188.0ᐳ"}}:::plan
+    Object17 & Access189 --> PgSelect190
+    List198{{"List[198∈10]<br />ᐸ196,197ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
+    Constant196{{"Constant[196∈10]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
+    PgClassExpression197{{"PgClassExpression[197∈10]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant196 & PgClassExpression197 --> List198
+    PgSelect204[["PgSelect[204∈10]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
+    Access203{{"Access[203∈10]<br />ᐸ202.0ᐳ"}}:::plan
+    Object17 & Access203 --> PgSelect204
+    List212{{"List[212∈10]<br />ᐸ210,211ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
+    Constant210{{"Constant[210∈10]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
+    PgClassExpression211{{"PgClassExpression[211∈10]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant210 & PgClassExpression211 --> List212
+    PgSelect399[["PgSelect[399∈18]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
+    Access398{{"Access[398∈18]<br />ᐸ397.0ᐳ"}}:::plan
+    Object17 & Access398 --> PgSelect399
+    List407{{"List[407∈18]<br />ᐸ405,406ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
+    Constant405{{"Constant[405∈18]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
+    PgClassExpression406{{"PgClassExpression[406∈18]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant405 & PgClassExpression406 --> List407
+    PgSelect413[["PgSelect[413∈18]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
+    Access412{{"Access[412∈18]<br />ᐸ411.0ᐳ"}}:::plan
+    Object17 & Access412 --> PgSelect413
+    List421{{"List[421∈18]<br />ᐸ419,420ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
+    Constant419{{"Constant[419∈18]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
+    PgClassExpression420{{"PgClassExpression[420∈18]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant419 & PgClassExpression420 --> List421
+    PgSelect511[["PgSelect[511∈22]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
+    Access510{{"Access[510∈22]<br />ᐸ509.0ᐳ"}}:::plan
+    Object17 & Access510 --> PgSelect511
+    List519{{"List[519∈22]<br />ᐸ517,518ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
+    Constant517{{"Constant[517∈22]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
+    PgClassExpression518{{"PgClassExpression[518∈22]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant517 & PgClassExpression518 --> List519
+    PgSelect525[["PgSelect[525∈22]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
+    Access524{{"Access[524∈22]<br />ᐸ523.0ᐳ"}}:::plan
+    Object17 & Access524 --> PgSelect525
+    List533{{"List[533∈22]<br />ᐸ531,532ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
+    Constant531{{"Constant[531∈22]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
+    PgClassExpression532{{"PgClassExpression[532∈22]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant531 & PgClassExpression532 --> List533
+    JSONParse76[["JSONParse[76∈6]<br />ᐸ75ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
+    Access75 --> JSONParse76
+    JSONParse76 --> Access77
+    First82{{"First[82∈6]"}}:::plan
+    PgSelect78 --> First82
+    PgSelectSingle83{{"PgSelectSingle[83∈6]<br />ᐸorganizationsᐳ"}}:::plan
+    First82 --> PgSelectSingle83
+    PgSelectSingle83 --> PgClassExpression85
+    Lambda87{{"Lambda[87∈6]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List86 --> Lambda87
+    PgClassExpression88{{"PgClassExpression[88∈6]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle83 --> PgClassExpression88
+    JSONParse90[["JSONParse[90∈6]<br />ᐸ75ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
+    Access75 --> JSONParse90
+    JSONParse90 --> Access91
+    First96{{"First[96∈6]"}}:::plan
+    PgSelect92 --> First96
+    PgSelectSingle97{{"PgSelectSingle[97∈6]<br />ᐸpeopleᐳ"}}:::plan
+    First96 --> PgSelectSingle97
+    PgSelectSingle97 --> PgClassExpression99
+    Lambda101{{"Lambda[101∈6]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List100 --> Lambda101
+    PgClassExpression102{{"PgClassExpression[102∈6]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle97 --> PgClassExpression102
+    JSONParse188[["JSONParse[188∈10]<br />ᐸ187ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
+    Access187 --> JSONParse188
+    JSONParse188 --> Access189
+    First194{{"First[194∈10]"}}:::plan
+    PgSelect190 --> First194
+    PgSelectSingle195{{"PgSelectSingle[195∈10]<br />ᐸorganizationsᐳ"}}:::plan
+    First194 --> PgSelectSingle195
+    PgSelectSingle195 --> PgClassExpression197
+    Lambda199{{"Lambda[199∈10]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List198 --> Lambda199
+    PgClassExpression200{{"PgClassExpression[200∈10]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle195 --> PgClassExpression200
+    JSONParse202[["JSONParse[202∈10]<br />ᐸ187ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
+    Access187 --> JSONParse202
+    JSONParse202 --> Access203
+    First208{{"First[208∈10]"}}:::plan
+    PgSelect204 --> First208
+    PgSelectSingle209{{"PgSelectSingle[209∈10]<br />ᐸpeopleᐳ"}}:::plan
+    First208 --> PgSelectSingle209
+    PgSelectSingle209 --> PgClassExpression211
+    Lambda213{{"Lambda[213∈10]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List212 --> Lambda213
+    PgClassExpression214{{"PgClassExpression[214∈10]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle209 --> PgClassExpression214
+    JSONParse397[["JSONParse[397∈18]<br />ᐸ396ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
+    Access396 --> JSONParse397
+    JSONParse397 --> Access398
+    First403{{"First[403∈18]"}}:::plan
+    PgSelect399 --> First403
+    PgSelectSingle404{{"PgSelectSingle[404∈18]<br />ᐸorganizationsᐳ"}}:::plan
+    First403 --> PgSelectSingle404
+    PgSelectSingle404 --> PgClassExpression406
+    Lambda408{{"Lambda[408∈18]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List407 --> Lambda408
+    PgClassExpression409{{"PgClassExpression[409∈18]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle404 --> PgClassExpression409
+    JSONParse411[["JSONParse[411∈18]<br />ᐸ396ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
+    Access396 --> JSONParse411
+    JSONParse411 --> Access412
+    First417{{"First[417∈18]"}}:::plan
+    PgSelect413 --> First417
+    PgSelectSingle418{{"PgSelectSingle[418∈18]<br />ᐸpeopleᐳ"}}:::plan
+    First417 --> PgSelectSingle418
+    PgSelectSingle418 --> PgClassExpression420
+    Lambda422{{"Lambda[422∈18]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List421 --> Lambda422
+    PgClassExpression423{{"PgClassExpression[423∈18]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle418 --> PgClassExpression423
+    JSONParse509[["JSONParse[509∈22]<br />ᐸ508ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
+    Access508 --> JSONParse509
+    JSONParse509 --> Access510
+    First515{{"First[515∈22]"}}:::plan
+    PgSelect511 --> First515
+    PgSelectSingle516{{"PgSelectSingle[516∈22]<br />ᐸorganizationsᐳ"}}:::plan
+    First515 --> PgSelectSingle516
+    PgSelectSingle516 --> PgClassExpression518
+    Lambda520{{"Lambda[520∈22]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List519 --> Lambda520
+    PgClassExpression521{{"PgClassExpression[521∈22]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle516 --> PgClassExpression521
+    JSONParse523[["JSONParse[523∈22]<br />ᐸ508ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
+    Access508 --> JSONParse523
+    JSONParse523 --> Access524
+    First529{{"First[529∈22]"}}:::plan
+    PgSelect525 --> First529
+    PgSelectSingle530{{"PgSelectSingle[530∈22]<br />ᐸpeopleᐳ"}}:::plan
+    First529 --> PgSelectSingle530
+    PgSelectSingle530 --> PgClassExpression532
+    Lambda534{{"Lambda[534∈22]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List533 --> Lambda534
+    PgClassExpression535{{"PgClassExpression[535∈22]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle530 --> PgClassExpression535
+
+    %% define steps
+
+    subgraph "Buckets for queries/polymorphic/vulns.union_owners"
+    Bucket0("Bucket 0 (root)"):::bucket
+    classDef bucket0 stroke:#696969
+    class Bucket0,__Value0,__Value3,__Value5,Access15,Access16,Object17,Connection18,Constant664 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 17, 18<br /><br />ROOT Connectionᐸ14ᐳ[18]"):::bucket
+    classDef bucket1 stroke:#00bfff
+    class Bucket1,PgUnionAll19 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 17<br /><br />ROOT __Item{2}ᐸ19ᐳ[20]"):::bucket
+    classDef bucket2 stroke:#7f007f
+    class Bucket2,__Item20,PgUnionAllSingle21,Access22 bucket2
+    Bucket3("Bucket 3 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 22, 17, 21<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br />1: JSONParse[23], JSONParse[344]<br />ᐳ: 31, 49, 273, 352, 370, 594, 24, 345<br />2: PgSelect[25], PgSelect[346]<br />ᐳ: 29, 30, 32, 33, 34, 35, 350, 351, 353, 354, 355, 356<br />3: 50, 159, 274, 309, 371, 480, 595, 630"):::bucket
+    classDef bucket3 stroke:#ffa500
+    class Bucket3,JSONParse23,Access24,PgSelect25,First29,PgSelectSingle30,Constant31,PgClassExpression32,List33,Lambda34,PgClassExpression35,Connection49,PgUnionAll50,PgUnionAll159,Connection273,PgUnionAll274,PgUnionAll309,JSONParse344,Access345,PgSelect346,First350,PgSelectSingle351,Constant352,PgClassExpression353,List354,Lambda355,PgClassExpression356,Connection370,PgUnionAll371,PgUnionAll480,Connection594,PgUnionAll595,PgUnionAll630 bucket3
+    Bucket4("Bucket 4 (listItem)<br />Deps: 17<br /><br />ROOT __Item{4}ᐸ50ᐳ[51]"):::bucket
+    classDef bucket4 stroke:#0000ff
+    class Bucket4,__Item51,PgUnionAllSingle52,Access53 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 53, 17, 52<br />ᐳFirstPartyVulnerabilityᐳAwsApplication<br />ᐳFirstPartyVulnerabilityᐳGcpApplication<br />1: JSONParse[54], JSONParse[104]<br />ᐳ: 62, 112, 55, 105<br />2: PgSelect[56], PgSelect[106]<br />ᐳ: 60, 61, 63, 64, 65, 66, 67, 68, 110, 111, 113, 114, 115, 116, 117, 118<br />3: PgUnionAll[69], PgUnionAll[119]<br />ᐳ: First[73], First[123]<br />4: 74, 124<br />ᐳ: Access[75], Access[125]"):::bucket
+    classDef bucket5 stroke:#7fff00
+    class Bucket5,JSONParse54,Access55,PgSelect56,First60,PgSelectSingle61,Constant62,PgClassExpression63,List64,Lambda65,PgClassExpression66,PgClassExpression67,PgClassExpression68,PgUnionAll69,First73,PgUnionAllSingle74,Access75,JSONParse104,Access105,PgSelect106,First110,PgSelectSingle111,Constant112,PgClassExpression113,List114,Lambda115,PgClassExpression116,PgClassExpression117,PgClassExpression118,PgUnionAll119,First123,PgUnionAllSingle124,Access125 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />Organization,Person<br />Deps: 75, 17, 74<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson<br />1: JSONParse[76], JSONParse[90]<br />ᐳ: 84, 98, 77, 91<br />2: PgSelect[78], PgSelect[92]<br />ᐳ: 82, 83, 85, 86, 87, 88, 96, 97, 99, 100, 101, 102"):::bucket
+    classDef bucket6 stroke:#ff1493
+    class Bucket6,JSONParse76,Access77,PgSelect78,First82,PgSelectSingle83,Constant84,PgClassExpression85,List86,Lambda87,PgClassExpression88,JSONParse90,Access91,PgSelect92,First96,PgSelectSingle97,Constant98,PgClassExpression99,List100,Lambda101,PgClassExpression102 bucket6
+    Bucket7("Bucket 7 (polymorphic)<br />Organization,Person<br />Deps: 125, 17, 124<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson<br />1: JSONParse[126], JSONParse[140]<br />ᐳ: 134, 148, 127, 141<br />2: PgSelect[128], PgSelect[142]<br />ᐳ: 132, 133, 135, 136, 137, 138, 146, 147, 149, 150, 151, 152"):::bucket
+    classDef bucket7 stroke:#808000
+    class Bucket7,JSONParse126,Access127,PgSelect128,First132,PgSelectSingle133,Constant134,PgClassExpression135,List136,Lambda137,PgClassExpression138,JSONParse140,Access141,PgSelect142,First146,PgSelectSingle147,Constant148,PgClassExpression149,List150,Lambda151,PgClassExpression152 bucket7
+    Bucket8("Bucket 8 (listItem)<br />Deps: 17<br /><br />ROOT __Item{8}ᐸ159ᐳ[163]"):::bucket
+    classDef bucket8 stroke:#dda0dd
+    class Bucket8,__Item163,PgUnionAllSingle164,Access165 bucket8
+    Bucket9("Bucket 9 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 165, 17, 164<br />ᐳFirstPartyVulnerabilityᐳAwsApplication<br />ᐳFirstPartyVulnerabilityᐳGcpApplication<br />1: JSONParse[166], JSONParse[216]<br />ᐳ: 174, 224, 167, 217<br />2: PgSelect[168], PgSelect[218]<br />ᐳ: 172, 173, 175, 176, 177, 178, 179, 180, 222, 223, 225, 226, 227, 228, 229, 230<br />3: PgUnionAll[181], PgUnionAll[231]<br />ᐳ: First[185], First[235]<br />4: 186, 236<br />ᐳ: Access[187], Access[237]"):::bucket
+    classDef bucket9 stroke:#ff0000
+    class Bucket9,JSONParse166,Access167,PgSelect168,First172,PgSelectSingle173,Constant174,PgClassExpression175,List176,Lambda177,PgClassExpression178,PgClassExpression179,PgClassExpression180,PgUnionAll181,First185,PgUnionAllSingle186,Access187,JSONParse216,Access217,PgSelect218,First222,PgSelectSingle223,Constant224,PgClassExpression225,List226,Lambda227,PgClassExpression228,PgClassExpression229,PgClassExpression230,PgUnionAll231,First235,PgUnionAllSingle236,Access237 bucket9
+    Bucket10("Bucket 10 (polymorphic)<br />Organization,Person<br />Deps: 187, 17, 186<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson<br />1: JSONParse[188], JSONParse[202]<br />ᐳ: 196, 210, 189, 203<br />2: PgSelect[190], PgSelect[204]<br />ᐳ: 194, 195, 197, 198, 199, 200, 208, 209, 211, 212, 213, 214"):::bucket
+    classDef bucket10 stroke:#ffff00
+    class Bucket10,JSONParse188,Access189,PgSelect190,First194,PgSelectSingle195,Constant196,PgClassExpression197,List198,Lambda199,PgClassExpression200,JSONParse202,Access203,PgSelect204,First208,PgSelectSingle209,Constant210,PgClassExpression211,List212,Lambda213,PgClassExpression214 bucket10
+    Bucket11("Bucket 11 (polymorphic)<br />Organization,Person<br />Deps: 237, 17, 236<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson<br />1: JSONParse[238], JSONParse[252]<br />ᐳ: 246, 260, 239, 253<br />2: PgSelect[240], PgSelect[254]<br />ᐳ: 244, 245, 247, 248, 249, 250, 258, 259, 261, 262, 263, 264"):::bucket
+    classDef bucket11 stroke:#00ffff
+    class Bucket11,JSONParse238,Access239,PgSelect240,First244,PgSelectSingle245,Constant246,PgClassExpression247,List248,Lambda249,PgClassExpression250,JSONParse252,Access253,PgSelect254,First258,PgSelectSingle259,Constant260,PgClassExpression261,List262,Lambda263,PgClassExpression264 bucket11
+    Bucket12("Bucket 12 (listItem)<br />Deps: 17<br /><br />ROOT __Item{12}ᐸ274ᐳ[275]"):::bucket
+    classDef bucket12 stroke:#4169e1
+    class Bucket12,__Item275,PgUnionAllSingle276,Access277 bucket12
+    Bucket13("Bucket 13 (polymorphic)<br />Organization,Person<br />Deps: 277, 17, 276<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br />1: JSONParse[278], JSONParse[292]<br />ᐳ: 286, 300, 279, 293<br />2: PgSelect[280], PgSelect[294]<br />ᐳ: 284, 285, 287, 288, 289, 290, 298, 299, 301, 302, 303, 304"):::bucket
+    classDef bucket13 stroke:#3cb371
+    class Bucket13,JSONParse278,Access279,PgSelect280,First284,PgSelectSingle285,Constant286,PgClassExpression287,List288,Lambda289,PgClassExpression290,JSONParse292,Access293,PgSelect294,First298,PgSelectSingle299,Constant300,PgClassExpression301,List302,Lambda303,PgClassExpression304 bucket13
+    Bucket14("Bucket 14 (listItem)<br />Deps: 17<br /><br />ROOT __Item{14}ᐸ309ᐳ[313]"):::bucket
+    classDef bucket14 stroke:#a52a2a
+    class Bucket14,__Item313,PgUnionAllSingle314,Access315 bucket14
+    Bucket15("Bucket 15 (polymorphic)<br />Organization,Person<br />Deps: 315, 17, 314<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br />1: JSONParse[316], JSONParse[330]<br />ᐳ: 324, 338, 317, 331<br />2: PgSelect[318], PgSelect[332]<br />ᐳ: 322, 323, 325, 326, 327, 328, 336, 337, 339, 340, 341, 342"):::bucket
+    classDef bucket15 stroke:#ff00ff
+    class Bucket15,JSONParse316,Access317,PgSelect318,First322,PgSelectSingle323,Constant324,PgClassExpression325,List326,Lambda327,PgClassExpression328,JSONParse330,Access331,PgSelect332,First336,PgSelectSingle337,Constant338,PgClassExpression339,List340,Lambda341,PgClassExpression342 bucket15
+    Bucket16("Bucket 16 (listItem)<br />Deps: 17<br /><br />ROOT __Item{16}ᐸ371ᐳ[372]"):::bucket
+    classDef bucket16 stroke:#f5deb3
+    class Bucket16,__Item372,PgUnionAllSingle373,Access374 bucket16
+    Bucket17("Bucket 17 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 374, 17, 373<br />ᐳThirdPartyVulnerabilityᐳAwsApplication<br />ᐳThirdPartyVulnerabilityᐳGcpApplication<br />1: JSONParse[375], JSONParse[425]<br />ᐳ: 383, 433, 376, 426<br />2: PgSelect[377], PgSelect[427]<br />ᐳ: 381, 382, 384, 385, 386, 387, 388, 389, 431, 432, 434, 435, 436, 437, 438, 439<br />3: PgUnionAll[390], PgUnionAll[440]<br />ᐳ: First[394], First[444]<br />4: 395, 445<br />ᐳ: Access[396], Access[446]"):::bucket
+    classDef bucket17 stroke:#696969
+    class Bucket17,JSONParse375,Access376,PgSelect377,First381,PgSelectSingle382,Constant383,PgClassExpression384,List385,Lambda386,PgClassExpression387,PgClassExpression388,PgClassExpression389,PgUnionAll390,First394,PgUnionAllSingle395,Access396,JSONParse425,Access426,PgSelect427,First431,PgSelectSingle432,Constant433,PgClassExpression434,List435,Lambda436,PgClassExpression437,PgClassExpression438,PgClassExpression439,PgUnionAll440,First444,PgUnionAllSingle445,Access446 bucket17
+    Bucket18("Bucket 18 (polymorphic)<br />Organization,Person<br />Deps: 396, 17, 395<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson<br />1: JSONParse[397], JSONParse[411]<br />ᐳ: 405, 419, 398, 412<br />2: PgSelect[399], PgSelect[413]<br />ᐳ: 403, 404, 406, 407, 408, 409, 417, 418, 420, 421, 422, 423"):::bucket
+    classDef bucket18 stroke:#00bfff
+    class Bucket18,JSONParse397,Access398,PgSelect399,First403,PgSelectSingle404,Constant405,PgClassExpression406,List407,Lambda408,PgClassExpression409,JSONParse411,Access412,PgSelect413,First417,PgSelectSingle418,Constant419,PgClassExpression420,List421,Lambda422,PgClassExpression423 bucket18
+    Bucket19("Bucket 19 (polymorphic)<br />Organization,Person<br />Deps: 446, 17, 445<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson<br />1: JSONParse[447], JSONParse[461]<br />ᐳ: 455, 469, 448, 462<br />2: PgSelect[449], PgSelect[463]<br />ᐳ: 453, 454, 456, 457, 458, 459, 467, 468, 470, 471, 472, 473"):::bucket
+    classDef bucket19 stroke:#7f007f
+    class Bucket19,JSONParse447,Access448,PgSelect449,First453,PgSelectSingle454,Constant455,PgClassExpression456,List457,Lambda458,PgClassExpression459,JSONParse461,Access462,PgSelect463,First467,PgSelectSingle468,Constant469,PgClassExpression470,List471,Lambda472,PgClassExpression473 bucket19
+    Bucket20("Bucket 20 (listItem)<br />Deps: 17<br /><br />ROOT __Item{20}ᐸ480ᐳ[484]"):::bucket
+    classDef bucket20 stroke:#ffa500
+    class Bucket20,__Item484,PgUnionAllSingle485,Access486 bucket20
+    Bucket21("Bucket 21 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 486, 17, 485<br />ᐳThirdPartyVulnerabilityᐳAwsApplication<br />ᐳThirdPartyVulnerabilityᐳGcpApplication<br />1: JSONParse[487], JSONParse[537]<br />ᐳ: 495, 545, 488, 538<br />2: PgSelect[489], PgSelect[539]<br />ᐳ: 493, 494, 496, 497, 498, 499, 500, 501, 543, 544, 546, 547, 548, 549, 550, 551<br />3: PgUnionAll[502], PgUnionAll[552]<br />ᐳ: First[506], First[556]<br />4: 507, 557<br />ᐳ: Access[508], Access[558]"):::bucket
+    classDef bucket21 stroke:#0000ff
+    class Bucket21,JSONParse487,Access488,PgSelect489,First493,PgSelectSingle494,Constant495,PgClassExpression496,List497,Lambda498,PgClassExpression499,PgClassExpression500,PgClassExpression501,PgUnionAll502,First506,PgUnionAllSingle507,Access508,JSONParse537,Access538,PgSelect539,First543,PgSelectSingle544,Constant545,PgClassExpression546,List547,Lambda548,PgClassExpression549,PgClassExpression550,PgClassExpression551,PgUnionAll552,First556,PgUnionAllSingle557,Access558 bucket21
+    Bucket22("Bucket 22 (polymorphic)<br />Organization,Person<br />Deps: 508, 17, 507<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson<br />1: JSONParse[509], JSONParse[523]<br />ᐳ: 517, 531, 510, 524<br />2: PgSelect[511], PgSelect[525]<br />ᐳ: 515, 516, 518, 519, 520, 521, 529, 530, 532, 533, 534, 535"):::bucket
+    classDef bucket22 stroke:#7fff00
+    class Bucket22,JSONParse509,Access510,PgSelect511,First515,PgSelectSingle516,Constant517,PgClassExpression518,List519,Lambda520,PgClassExpression521,JSONParse523,Access524,PgSelect525,First529,PgSelectSingle530,Constant531,PgClassExpression532,List533,Lambda534,PgClassExpression535 bucket22
+    Bucket23("Bucket 23 (polymorphic)<br />Organization,Person<br />Deps: 558, 17, 557<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson<br />1: JSONParse[559], JSONParse[573]<br />ᐳ: 567, 581, 560, 574<br />2: PgSelect[561], PgSelect[575]<br />ᐳ: 565, 566, 568, 569, 570, 571, 579, 580, 582, 583, 584, 585"):::bucket
+    classDef bucket23 stroke:#ff1493
+    class Bucket23,JSONParse559,Access560,PgSelect561,First565,PgSelectSingle566,Constant567,PgClassExpression568,List569,Lambda570,PgClassExpression571,JSONParse573,Access574,PgSelect575,First579,PgSelectSingle580,Constant581,PgClassExpression582,List583,Lambda584,PgClassExpression585 bucket23
+    Bucket24("Bucket 24 (listItem)<br />Deps: 17<br /><br />ROOT __Item{24}ᐸ595ᐳ[596]"):::bucket
+    classDef bucket24 stroke:#808000
+    class Bucket24,__Item596,PgUnionAllSingle597,Access598 bucket24
+    Bucket25("Bucket 25 (polymorphic)<br />Organization,Person<br />Deps: 598, 17, 597<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br />1: JSONParse[599], JSONParse[613]<br />ᐳ: 607, 621, 600, 614<br />2: PgSelect[601], PgSelect[615]<br />ᐳ: 605, 606, 608, 609, 610, 611, 619, 620, 622, 623, 624, 625"):::bucket
+    classDef bucket25 stroke:#dda0dd
+    class Bucket25,JSONParse599,Access600,PgSelect601,First605,PgSelectSingle606,Constant607,PgClassExpression608,List609,Lambda610,PgClassExpression611,JSONParse613,Access614,PgSelect615,First619,PgSelectSingle620,Constant621,PgClassExpression622,List623,Lambda624,PgClassExpression625 bucket25
+    Bucket26("Bucket 26 (listItem)<br />Deps: 17<br /><br />ROOT __Item{26}ᐸ630ᐳ[634]"):::bucket
+    classDef bucket26 stroke:#ff0000
+    class Bucket26,__Item634,PgUnionAllSingle635,Access636 bucket26
+    Bucket27("Bucket 27 (polymorphic)<br />Organization,Person<br />Deps: 636, 17, 635<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br />1: JSONParse[637], JSONParse[651]<br />ᐳ: 645, 659, 638, 652<br />2: PgSelect[639], PgSelect[653]<br />ᐳ: 643, 644, 646, 647, 648, 649, 657, 658, 660, 661, 662, 663"):::bucket
+    classDef bucket27 stroke:#ffff00
+    class Bucket27,JSONParse637,Access638,PgSelect639,First643,PgSelectSingle644,Constant645,PgClassExpression646,List647,Lambda648,PgClassExpression649,JSONParse651,Access652,PgSelect653,First657,PgSelectSingle658,Constant659,PgClassExpression660,List661,Lambda662,PgClassExpression663 bucket27
+    Bucket0 --> Bucket1
+    Bucket1 --> Bucket2
+    Bucket2 --> Bucket3
+    Bucket3 --> Bucket4 & Bucket8 & Bucket12 & Bucket14 & Bucket16 & Bucket20 & Bucket24 & Bucket26
+    Bucket4 --> Bucket5
+    Bucket5 --> Bucket6 & Bucket7
+    Bucket8 --> Bucket9
+    Bucket9 --> Bucket10 & Bucket11
+    Bucket12 --> Bucket13
+    Bucket14 --> Bucket15
+    Bucket16 --> Bucket17
+    Bucket17 --> Bucket18 & Bucket19
+    Bucket20 --> Bucket21
+    Bucket21 --> Bucket22 & Bucket23
+    Bucket24 --> Bucket25
+    Bucket26 --> Bucket27
+    end

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.simple.json5
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.simple.json5
@@ -1,0 +1,62 @@
+{
+  allVulnerabilities: {
+    nodes: [
+      {
+        id: "WyJmaXJzdF9wYXJ0eV92dWxuZXJhYmlsaXRpZXMiLDFd",
+        name: "Off-by-one",
+        owners: {
+          nodes: [
+            {
+              __typename: "Organization",
+              id: "WyJvcmdhbml6YXRpb25zIiwxXQ==",
+              name: "Acme",
+            },
+            {
+              __typename: "Organization",
+              id: "WyJvcmdhbml6YXRpb25zIiwxXQ==",
+              name: "Acme",
+            },
+            {
+              __typename: "Organization",
+              id: "WyJvcmdhbml6YXRpb25zIiw1XQ==",
+              name: "Cyberdyne Systems",
+            },
+            {
+              __typename: "Person",
+              id: "WyJwZW9wbGUiLDFd",
+              username: "Alice",
+            },
+            {
+              __typename: "Person",
+              id: "WyJwZW9wbGUiLDJd",
+              username: "Benjie",
+            },
+          ],
+        },
+      },
+      {
+        id: "WyJmaXJzdF9wYXJ0eV92dWxuZXJhYmlsaXRpZXMiLDJd",
+        name: "Index-out-of-bounds",
+        owners: {
+          nodes: [
+            {
+              __typename: "Organization",
+              id: "WyJvcmdhbml6YXRpb25zIiwxXQ==",
+              name: "Acme",
+            },
+            {
+              __typename: "Person",
+              id: "WyJwZW9wbGUiLDJd",
+              username: "Benjie",
+            },
+            {
+              __typename: "Person",
+              id: "WyJwZW9wbGUiLDNd",
+              username: "Caroline",
+            },
+          ],
+        },
+      },
+    ],
+  },
+}

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.simple.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.simple.mermaid
@@ -1,0 +1,198 @@
+%%{init: {'themeVariables': { 'fontSize': '12px'}}}%%
+graph TD
+    classDef path fill:#eee,stroke:#000,color:#000
+    classDef plan fill:#fff,stroke-width:1px,color:#000
+    classDef itemplan fill:#fff,stroke-width:2px,color:#000
+    classDef unbatchedplan fill:#dff,stroke-width:1px,color:#000
+    classDef sideeffectplan fill:#fcc,stroke-width:2px,color:#000
+    classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
+
+
+    %% plan dependencies
+    Object17{{"Object[17∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access15{{"Access[15∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access16{{"Access[16∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access15 & Access16 --> Object17
+    __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
+    __Value3 --> Access15
+    __Value3 --> Access16
+    Connection18{{"Connection[18∈0]<br />ᐸ14ᐳ"}}:::plan
+    Constant130{{"Constant[130∈0]<br />ᐸ2ᐳ"}}:::plan
+    Constant130 --> Connection18
+    __Value0["__Value[0∈0]"]:::plan
+    __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
+    PgUnionAll19[["PgUnionAll[19∈1]"]]:::plan
+    Object17 & Connection18 --> PgUnionAll19
+    __Item20[/"__Item[20∈2]<br />ᐸ19ᐳ"\]:::itemplan
+    PgUnionAll19 ==> __Item20
+    PgUnionAllSingle21["PgUnionAllSingle[21∈2]"]:::plan
+    __Item20 --> PgUnionAllSingle21
+    Access22{{"Access[22∈2]<br />ᐸ21.1ᐳ"}}:::plan
+    PgUnionAllSingle21 --> Access22
+    PgUnionAll45[["PgUnionAll[45∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
+    PgClassExpression32{{"PgClassExpression[32∈3]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
+    Connection44{{"Connection[44∈3]<br />ᐸ40ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
+    Object17 & PgClassExpression32 & PgClassExpression32 & PgClassExpression32 & PgClassExpression32 & Connection44 --> PgUnionAll45
+    PgUnionAll99[["PgUnionAll[99∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
+    PgClassExpression86{{"PgClassExpression[86∈3]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
+    Connection98{{"Connection[98∈3]<br />ᐸ94ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
+    Object17 & PgClassExpression86 & PgClassExpression86 & PgClassExpression86 & PgClassExpression86 & Connection98 --> PgUnionAll99
+    PgSelect25[["PgSelect[25∈3]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
+    Access24{{"Access[24∈3]<br />ᐸ23.0ᐳ"}}:::plan
+    Object17 & Access24 --> PgSelect25
+    List33{{"List[33∈3]<br />ᐸ31,32ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
+    Constant31{{"Constant[31∈3]<br />ᐸ'first_party_vulnerabilities'ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
+    Constant31 & PgClassExpression32 --> List33
+    PgSelect79[["PgSelect[79∈3]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
+    Access78{{"Access[78∈3]<br />ᐸ77.0ᐳ"}}:::plan
+    Object17 & Access78 --> PgSelect79
+    List87{{"List[87∈3]<br />ᐸ85,86ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
+    Constant85{{"Constant[85∈3]<br />ᐸ'third_party_vulnerabilities'ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
+    Constant85 & PgClassExpression86 --> List87
+    JSONParse23[["JSONParse[23∈3]<br />ᐸ22ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
+    Access22 --> JSONParse23
+    JSONParse23 --> Access24
+    First29{{"First[29∈3]"}}:::plan
+    PgSelect25 --> First29
+    PgSelectSingle30{{"PgSelectSingle[30∈3]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
+    First29 --> PgSelectSingle30
+    PgSelectSingle30 --> PgClassExpression32
+    Lambda34{{"Lambda[34∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List33 --> Lambda34
+    PgClassExpression35{{"PgClassExpression[35∈3]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle30 --> PgClassExpression35
+    JSONParse77[["JSONParse[77∈3]<br />ᐸ22ᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
+    Access22 --> JSONParse77
+    JSONParse77 --> Access78
+    First83{{"First[83∈3]"}}:::plan
+    PgSelect79 --> First83
+    PgSelectSingle84{{"PgSelectSingle[84∈3]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
+    First83 --> PgSelectSingle84
+    PgSelectSingle84 --> PgClassExpression86
+    Lambda88{{"Lambda[88∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List87 --> Lambda88
+    PgClassExpression89{{"PgClassExpression[89∈3]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle84 --> PgClassExpression89
+    __Item100[/"__Item[100∈6]<br />ᐸ99ᐳ"\]:::itemplan
+    PgUnionAll99 ==> __Item100
+    PgUnionAllSingle101["PgUnionAllSingle[101∈6]"]:::plan
+    __Item100 --> PgUnionAllSingle101
+    Access102{{"Access[102∈6]<br />ᐸ101.1ᐳ"}}:::plan
+    PgUnionAllSingle101 --> Access102
+    __Item46[/"__Item[46∈4]<br />ᐸ45ᐳ"\]:::itemplan
+    PgUnionAll45 ==> __Item46
+    PgUnionAllSingle47["PgUnionAllSingle[47∈4]"]:::plan
+    __Item46 --> PgUnionAllSingle47
+    Access48{{"Access[48∈4]<br />ᐸ47.1ᐳ"}}:::plan
+    PgUnionAllSingle47 --> Access48
+    PgSelect51[["PgSelect[51∈5]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
+    Access50{{"Access[50∈5]<br />ᐸ49.0ᐳ"}}:::plan
+    Object17 & Access50 --> PgSelect51
+    List59{{"List[59∈5]<br />ᐸ57,58ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
+    Constant57{{"Constant[57∈5]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
+    PgClassExpression58{{"PgClassExpression[58∈5]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant57 & PgClassExpression58 --> List59
+    PgSelect65[["PgSelect[65∈5]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
+    Access64{{"Access[64∈5]<br />ᐸ63.0ᐳ"}}:::plan
+    Object17 & Access64 --> PgSelect65
+    List73{{"List[73∈5]<br />ᐸ71,72ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
+    Constant71{{"Constant[71∈5]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
+    PgClassExpression72{{"PgClassExpression[72∈5]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant71 & PgClassExpression72 --> List73
+    PgSelect105[["PgSelect[105∈7]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
+    Access104{{"Access[104∈7]<br />ᐸ103.0ᐳ"}}:::plan
+    Object17 & Access104 --> PgSelect105
+    List113{{"List[113∈7]<br />ᐸ111,112ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
+    Constant111{{"Constant[111∈7]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
+    PgClassExpression112{{"PgClassExpression[112∈7]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant111 & PgClassExpression112 --> List113
+    PgSelect119[["PgSelect[119∈7]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
+    Access118{{"Access[118∈7]<br />ᐸ117.0ᐳ"}}:::plan
+    Object17 & Access118 --> PgSelect119
+    List127{{"List[127∈7]<br />ᐸ125,126ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
+    Constant125{{"Constant[125∈7]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
+    PgClassExpression126{{"PgClassExpression[126∈7]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant125 & PgClassExpression126 --> List127
+    JSONParse49[["JSONParse[49∈5]<br />ᐸ48ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
+    Access48 --> JSONParse49
+    JSONParse49 --> Access50
+    First55{{"First[55∈5]"}}:::plan
+    PgSelect51 --> First55
+    PgSelectSingle56{{"PgSelectSingle[56∈5]<br />ᐸorganizationsᐳ"}}:::plan
+    First55 --> PgSelectSingle56
+    PgSelectSingle56 --> PgClassExpression58
+    Lambda60{{"Lambda[60∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List59 --> Lambda60
+    PgClassExpression61{{"PgClassExpression[61∈5]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle56 --> PgClassExpression61
+    JSONParse63[["JSONParse[63∈5]<br />ᐸ48ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
+    Access48 --> JSONParse63
+    JSONParse63 --> Access64
+    First69{{"First[69∈5]"}}:::plan
+    PgSelect65 --> First69
+    PgSelectSingle70{{"PgSelectSingle[70∈5]<br />ᐸpeopleᐳ"}}:::plan
+    First69 --> PgSelectSingle70
+    PgSelectSingle70 --> PgClassExpression72
+    Lambda74{{"Lambda[74∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List73 --> Lambda74
+    PgClassExpression75{{"PgClassExpression[75∈5]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle70 --> PgClassExpression75
+    JSONParse103[["JSONParse[103∈7]<br />ᐸ102ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
+    Access102 --> JSONParse103
+    JSONParse103 --> Access104
+    First109{{"First[109∈7]"}}:::plan
+    PgSelect105 --> First109
+    PgSelectSingle110{{"PgSelectSingle[110∈7]<br />ᐸorganizationsᐳ"}}:::plan
+    First109 --> PgSelectSingle110
+    PgSelectSingle110 --> PgClassExpression112
+    Lambda114{{"Lambda[114∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List113 --> Lambda114
+    PgClassExpression115{{"PgClassExpression[115∈7]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle110 --> PgClassExpression115
+    JSONParse117[["JSONParse[117∈7]<br />ᐸ102ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
+    Access102 --> JSONParse117
+    JSONParse117 --> Access118
+    First123{{"First[123∈7]"}}:::plan
+    PgSelect119 --> First123
+    PgSelectSingle124{{"PgSelectSingle[124∈7]<br />ᐸpeopleᐳ"}}:::plan
+    First123 --> PgSelectSingle124
+    PgSelectSingle124 --> PgClassExpression126
+    Lambda128{{"Lambda[128∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List127 --> Lambda128
+    PgClassExpression129{{"PgClassExpression[129∈7]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle124 --> PgClassExpression129
+
+    %% define steps
+
+    subgraph "Buckets for queries/polymorphic/vulns.union_owners.simple"
+    Bucket0("Bucket 0 (root)"):::bucket
+    classDef bucket0 stroke:#696969
+    class Bucket0,__Value0,__Value3,__Value5,Access15,Access16,Object17,Connection18,Constant130 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 17, 18<br /><br />ROOT Connectionᐸ14ᐳ[18]"):::bucket
+    classDef bucket1 stroke:#00bfff
+    class Bucket1,PgUnionAll19 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 17<br /><br />ROOT __Item{2}ᐸ19ᐳ[20]"):::bucket
+    classDef bucket2 stroke:#7f007f
+    class Bucket2,__Item20,PgUnionAllSingle21,Access22 bucket2
+    Bucket3("Bucket 3 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 22, 17, 21<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br />1: JSONParse[23], JSONParse[77]<br />ᐳ: 31, 44, 85, 98, 24, 78<br />2: PgSelect[25], PgSelect[79]<br />ᐳ: 29, 30, 32, 33, 34, 35, 83, 84, 86, 87, 88, 89<br />3: PgUnionAll[45], PgUnionAll[99]"):::bucket
+    classDef bucket3 stroke:#ffa500
+    class Bucket3,JSONParse23,Access24,PgSelect25,First29,PgSelectSingle30,Constant31,PgClassExpression32,List33,Lambda34,PgClassExpression35,Connection44,PgUnionAll45,JSONParse77,Access78,PgSelect79,First83,PgSelectSingle84,Constant85,PgClassExpression86,List87,Lambda88,PgClassExpression89,Connection98,PgUnionAll99 bucket3
+    Bucket4("Bucket 4 (listItem)<br />Deps: 17<br /><br />ROOT __Item{4}ᐸ45ᐳ[46]"):::bucket
+    classDef bucket4 stroke:#0000ff
+    class Bucket4,__Item46,PgUnionAllSingle47,Access48 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />Organization,Person<br />Deps: 48, 17, 47<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br />1: JSONParse[49], JSONParse[63]<br />ᐳ: 57, 71, 50, 64<br />2: PgSelect[51], PgSelect[65]<br />ᐳ: 55, 56, 58, 59, 60, 61, 69, 70, 72, 73, 74, 75"):::bucket
+    classDef bucket5 stroke:#7fff00
+    class Bucket5,JSONParse49,Access50,PgSelect51,First55,PgSelectSingle56,Constant57,PgClassExpression58,List59,Lambda60,PgClassExpression61,JSONParse63,Access64,PgSelect65,First69,PgSelectSingle70,Constant71,PgClassExpression72,List73,Lambda74,PgClassExpression75 bucket5
+    Bucket6("Bucket 6 (listItem)<br />Deps: 17<br /><br />ROOT __Item{6}ᐸ99ᐳ[100]"):::bucket
+    classDef bucket6 stroke:#ff1493
+    class Bucket6,__Item100,PgUnionAllSingle101,Access102 bucket6
+    Bucket7("Bucket 7 (polymorphic)<br />Organization,Person<br />Deps: 102, 17, 101<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br />1: JSONParse[103], JSONParse[117]<br />ᐳ: 111, 125, 104, 118<br />2: PgSelect[105], PgSelect[119]<br />ᐳ: 109, 110, 112, 113, 114, 115, 123, 124, 126, 127, 128, 129"):::bucket
+    classDef bucket7 stroke:#808000
+    class Bucket7,JSONParse103,Access104,PgSelect105,First109,PgSelectSingle110,Constant111,PgClassExpression112,List113,Lambda114,PgClassExpression115,JSONParse117,Access118,PgSelect119,First123,PgSelectSingle124,Constant125,PgClassExpression126,List127,Lambda128,PgClassExpression129 bucket7
+    Bucket0 --> Bucket1
+    Bucket1 --> Bucket2
+    Bucket2 --> Bucket3
+    Bucket3 --> Bucket4 & Bucket6
+    Bucket4 --> Bucket5
+    Bucket6 --> Bucket7
+    end

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.simple.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.simple.sql
@@ -1,0 +1,201 @@
+select
+  __vulnerability__."0" as "0",
+  __vulnerability__."1"::text as "1"
+from (
+    select
+      __first_party_vulnerabilities__."0",
+      __first_party_vulnerabilities__."1",
+      "n"
+    from (
+      select
+        'FirstPartyVulnerability' as "0",
+        json_build_array((__first_party_vulnerabilities__."id")::text) as "1",
+        row_number() over (
+          order by
+            __first_party_vulnerabilities__."id" asc
+        ) as "n"
+      from "polymorphic"."first_party_vulnerabilities" as __first_party_vulnerabilities__
+      order by
+        __first_party_vulnerabilities__."id" asc
+      limit 2
+    ) as __first_party_vulnerabilities__
+  union all
+    select
+      __third_party_vulnerabilities__."0",
+      __third_party_vulnerabilities__."1",
+      "n"
+    from (
+      select
+        'ThirdPartyVulnerability' as "0",
+        json_build_array((__third_party_vulnerabilities__."id")::text) as "1",
+        row_number() over (
+          order by
+            __third_party_vulnerabilities__."id" asc
+        ) as "n"
+      from "polymorphic"."third_party_vulnerabilities" as __third_party_vulnerabilities__
+      order by
+        __third_party_vulnerabilities__."id" asc
+      limit 2
+    ) as __third_party_vulnerabilities__
+  order by
+    "0" asc,
+    "n" asc
+  limit 2
+) __vulnerability__
+
+
+select __first_party_vulnerabilities_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __first_party_vulnerabilities_identifiers__,
+lateral (
+  select
+    __first_party_vulnerabilities__."id"::text as "0",
+    __first_party_vulnerabilities__."name" as "1",
+    __first_party_vulnerabilities_identifiers__.idx as "2"
+  from "polymorphic"."first_party_vulnerabilities" as __first_party_vulnerabilities__
+  where (
+    __first_party_vulnerabilities__."id" = __first_party_vulnerabilities_identifiers__."id0"
+  )
+) as __first_party_vulnerabilities_result__;
+
+select __union_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0", (ids.value->>1)::"int4" as "id1", (ids.value->>2)::"int4" as "id2", (ids.value->>3)::"int4" as "id3" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+lateral (
+  select
+    __owners__."0" as "0",
+    __owners__."1"::text as "1",
+    __union_identifiers__.idx as "2"
+  from (
+      select
+        __people__."0",
+        __people__."1",
+        "n"
+      from (
+        select
+          'Person' as "0",
+          json_build_array((__people__."person_id")::text) as "1",
+          row_number() over (
+            order by
+              __people__."person_id" asc
+          ) as "n"
+        from "polymorphic"."aws_application_first_party_vulnerabilities" as __aws_application_first_party_vulnerabilities__
+        inner join "polymorphic"."aws_applications" as __aws_applications__
+        on (
+          __aws_applications__."id" = __aws_application_first_party_vulnerabilities__."aws_application_id"
+        )
+        inner join "polymorphic"."people" as __people__
+        on (
+          __people__."person_id" = __aws_applications__."person_id"
+        )
+        where __aws_application_first_party_vulnerabilities__."first_party_vulnerability_id" = __union_identifiers__."id0"
+        order by
+          __people__."person_id" asc
+      ) as __people__
+    union all
+      select
+        __organizations__."0",
+        __organizations__."1",
+        "n"
+      from (
+        select
+          'Organization' as "0",
+          json_build_array((__organizations__."organization_id")::text) as "1",
+          row_number() over (
+            order by
+              __organizations__."organization_id" asc
+          ) as "n"
+        from "polymorphic"."aws_application_first_party_vulnerabilities" as __aws_application_first_party_vulnerabilities_2
+        inner join "polymorphic"."aws_applications" as __aws_applications_2
+        on (
+          __aws_applications_2."id" = __aws_application_first_party_vulnerabilities_2."aws_application_id"
+        )
+        inner join "polymorphic"."organizations" as __organizations__
+        on (
+          __organizations__."organization_id" = __aws_applications_2."organization_id"
+        )
+        where __aws_application_first_party_vulnerabilities_2."first_party_vulnerability_id" = __union_identifiers__."id1"
+        order by
+          __organizations__."organization_id" asc
+      ) as __organizations__
+    union all
+      select
+        __people_2."0",
+        __people_2."1",
+        "n"
+      from (
+        select
+          'Person' as "0",
+          json_build_array((__people_2."person_id")::text) as "1",
+          row_number() over (
+            order by
+              __people_2."person_id" asc
+          ) as "n"
+        from "polymorphic"."gcp_application_first_party_vulnerabilities" as __gcp_application_first_party_vulnerabilities__
+        inner join "polymorphic"."gcp_applications" as __gcp_applications__
+        on (
+          __gcp_applications__."id" = __gcp_application_first_party_vulnerabilities__."gcp_application_id"
+        )
+        inner join "polymorphic"."people" as __people_2
+        on (
+          __people_2."person_id" = __gcp_applications__."person_id"
+        )
+        where __gcp_application_first_party_vulnerabilities__."first_party_vulnerability_id" = __union_identifiers__."id2"
+        order by
+          __people_2."person_id" asc
+      ) as __people_2
+    union all
+      select
+        __organizations_2."0",
+        __organizations_2."1",
+        "n"
+      from (
+        select
+          'Organization' as "0",
+          json_build_array((__organizations_2."organization_id")::text) as "1",
+          row_number() over (
+            order by
+              __organizations_2."organization_id" asc
+          ) as "n"
+        from "polymorphic"."gcp_application_first_party_vulnerabilities" as __gcp_application_first_party_vulnerabilities_2
+        inner join "polymorphic"."gcp_applications" as __gcp_applications_2
+        on (
+          __gcp_applications_2."id" = __gcp_application_first_party_vulnerabilities_2."gcp_application_id"
+        )
+        inner join "polymorphic"."organizations" as __organizations_2
+        on (
+          __organizations_2."organization_id" = __gcp_applications_2."organization_id"
+        )
+        where __gcp_application_first_party_vulnerabilities_2."first_party_vulnerability_id" = __union_identifiers__."id3"
+        order by
+          __organizations_2."organization_id" asc
+      ) as __organizations_2
+    order by
+      "0" asc,
+      "n" asc
+  ) __owners__
+) as __union_result__;
+
+select __organizations_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __organizations_identifiers__,
+lateral (
+  select
+    __organizations__."organization_id"::text as "0",
+    __organizations__."name" as "1",
+    __organizations_identifiers__.idx as "2"
+  from "polymorphic"."organizations" as __organizations__
+  where (
+    __organizations__."organization_id" = __organizations_identifiers__."id0"
+  )
+) as __organizations_result__;
+
+select __people_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+lateral (
+  select
+    __people__."person_id"::text as "0",
+    __people__."username" as "1",
+    __people_identifiers__.idx as "2"
+  from "polymorphic"."people" as __people__
+  where (
+    __people__."person_id" = __people_identifiers__."id0"
+  )
+) as __people_result__;

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.simple.test.graphql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.simple.test.graphql
@@ -1,0 +1,30 @@
+## expect(errors).toBeFalsy()
+#> schema: ["polymorphic"]
+#> simpleCollections: "both"
+#> classicIds: true
+
+{
+  allVulnerabilities(first: 2) {
+    nodes {
+      id
+      name
+      owners {
+        nodes {
+          __typename
+          ...Owner
+        }
+      }
+    }
+  }
+}
+
+fragment Owner on PersonOrOrganization {
+  ... on Organization {
+    id
+    name
+  }
+  ... on Person {
+    id
+    username
+  }
+}

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.sql
@@ -1,0 +1,386 @@
+select
+  __vulnerability__."0" as "0",
+  __vulnerability__."1"::text as "1"
+from (
+    select
+      __first_party_vulnerabilities__."0",
+      __first_party_vulnerabilities__."1",
+      "n"
+    from (
+      select
+        'FirstPartyVulnerability' as "0",
+        json_build_array((__first_party_vulnerabilities__."id")::text) as "1",
+        row_number() over (
+          order by
+            __first_party_vulnerabilities__."id" asc
+        ) as "n"
+      from "polymorphic"."first_party_vulnerabilities" as __first_party_vulnerabilities__
+      order by
+        __first_party_vulnerabilities__."id" asc
+      limit 2
+    ) as __first_party_vulnerabilities__
+  union all
+    select
+      __third_party_vulnerabilities__."0",
+      __third_party_vulnerabilities__."1",
+      "n"
+    from (
+      select
+        'ThirdPartyVulnerability' as "0",
+        json_build_array((__third_party_vulnerabilities__."id")::text) as "1",
+        row_number() over (
+          order by
+            __third_party_vulnerabilities__."id" asc
+        ) as "n"
+      from "polymorphic"."third_party_vulnerabilities" as __third_party_vulnerabilities__
+      order by
+        __third_party_vulnerabilities__."id" asc
+      limit 2
+    ) as __third_party_vulnerabilities__
+  order by
+    "0" asc,
+    "n" asc
+  limit 2
+) __vulnerability__
+
+
+select __first_party_vulnerabilities_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __first_party_vulnerabilities_identifiers__,
+lateral (
+  select
+    __first_party_vulnerabilities__."id"::text as "0",
+    __first_party_vulnerabilities__."name" as "1",
+    __first_party_vulnerabilities_identifiers__.idx as "2"
+  from "polymorphic"."first_party_vulnerabilities" as __first_party_vulnerabilities__
+  where (
+    __first_party_vulnerabilities__."id" = __first_party_vulnerabilities_identifiers__."id0"
+  )
+) as __first_party_vulnerabilities_result__;
+
+select __union_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0", (ids.value->>1)::"int4" as "id1" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+lateral (
+  select
+    __applications__."0" as "0",
+    __applications__."1"::text as "1",
+    __union_identifiers__.idx as "2"
+  from (
+      select
+        __aws_applications__."0",
+        __aws_applications__."1",
+        "n"
+      from (
+        select
+          'AwsApplication' as "0",
+          json_build_array((__aws_applications__."id")::text) as "1",
+          row_number() over (
+            order by
+              __aws_applications__."id" asc
+          ) as "n"
+        from "polymorphic"."aws_application_first_party_vulnerabilities" as __aws_application_first_party_vulnerabilities__
+        inner join "polymorphic"."aws_applications" as __aws_applications__
+        on (
+          __aws_applications__."id" = __aws_application_first_party_vulnerabilities__."aws_application_id"
+        )
+        where __aws_application_first_party_vulnerabilities__."first_party_vulnerability_id" = __union_identifiers__."id0"
+        order by
+          __aws_applications__."id" asc
+      ) as __aws_applications__
+    union all
+      select
+        __gcp_applications__."0",
+        __gcp_applications__."1",
+        "n"
+      from (
+        select
+          'GcpApplication' as "0",
+          json_build_array((__gcp_applications__."id")::text) as "1",
+          row_number() over (
+            order by
+              __gcp_applications__."id" asc
+          ) as "n"
+        from "polymorphic"."gcp_application_first_party_vulnerabilities" as __gcp_application_first_party_vulnerabilities__
+        inner join "polymorphic"."gcp_applications" as __gcp_applications__
+        on (
+          __gcp_applications__."id" = __gcp_application_first_party_vulnerabilities__."gcp_application_id"
+        )
+        where __gcp_application_first_party_vulnerabilities__."first_party_vulnerability_id" = __union_identifiers__."id1"
+        order by
+          __gcp_applications__."id" asc
+      ) as __gcp_applications__
+    order by
+      "0" asc,
+      "n" asc
+  ) __applications__
+) as __union_result__;
+
+select __union_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0", (ids.value->>1)::"int4" as "id1", (ids.value->>2)::"int4" as "id2", (ids.value->>3)::"int4" as "id3" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+lateral (
+  select
+    __owners__."0" as "0",
+    __owners__."1"::text as "1",
+    __union_identifiers__.idx as "2"
+  from (
+      select
+        __people__."0",
+        __people__."1",
+        "n"
+      from (
+        select
+          'Person' as "0",
+          json_build_array((__people__."person_id")::text) as "1",
+          row_number() over (
+            order by
+              __people__."person_id" asc
+          ) as "n"
+        from "polymorphic"."aws_application_first_party_vulnerabilities" as __aws_application_first_party_vulnerabilities__
+        inner join "polymorphic"."aws_applications" as __aws_applications__
+        on (
+          __aws_applications__."id" = __aws_application_first_party_vulnerabilities__."aws_application_id"
+        )
+        inner join "polymorphic"."people" as __people__
+        on (
+          __people__."person_id" = __aws_applications__."person_id"
+        )
+        where __aws_application_first_party_vulnerabilities__."first_party_vulnerability_id" = __union_identifiers__."id0"
+        order by
+          __people__."person_id" asc
+      ) as __people__
+    union all
+      select
+        __organizations__."0",
+        __organizations__."1",
+        "n"
+      from (
+        select
+          'Organization' as "0",
+          json_build_array((__organizations__."organization_id")::text) as "1",
+          row_number() over (
+            order by
+              __organizations__."organization_id" asc
+          ) as "n"
+        from "polymorphic"."aws_application_first_party_vulnerabilities" as __aws_application_first_party_vulnerabilities_2
+        inner join "polymorphic"."aws_applications" as __aws_applications_2
+        on (
+          __aws_applications_2."id" = __aws_application_first_party_vulnerabilities_2."aws_application_id"
+        )
+        inner join "polymorphic"."organizations" as __organizations__
+        on (
+          __organizations__."organization_id" = __aws_applications_2."organization_id"
+        )
+        where __aws_application_first_party_vulnerabilities_2."first_party_vulnerability_id" = __union_identifiers__."id1"
+        order by
+          __organizations__."organization_id" asc
+      ) as __organizations__
+    union all
+      select
+        __people_2."0",
+        __people_2."1",
+        "n"
+      from (
+        select
+          'Person' as "0",
+          json_build_array((__people_2."person_id")::text) as "1",
+          row_number() over (
+            order by
+              __people_2."person_id" asc
+          ) as "n"
+        from "polymorphic"."gcp_application_first_party_vulnerabilities" as __gcp_application_first_party_vulnerabilities__
+        inner join "polymorphic"."gcp_applications" as __gcp_applications__
+        on (
+          __gcp_applications__."id" = __gcp_application_first_party_vulnerabilities__."gcp_application_id"
+        )
+        inner join "polymorphic"."people" as __people_2
+        on (
+          __people_2."person_id" = __gcp_applications__."person_id"
+        )
+        where __gcp_application_first_party_vulnerabilities__."first_party_vulnerability_id" = __union_identifiers__."id2"
+        order by
+          __people_2."person_id" asc
+      ) as __people_2
+    union all
+      select
+        __organizations_2."0",
+        __organizations_2."1",
+        "n"
+      from (
+        select
+          'Organization' as "0",
+          json_build_array((__organizations_2."organization_id")::text) as "1",
+          row_number() over (
+            order by
+              __organizations_2."organization_id" asc
+          ) as "n"
+        from "polymorphic"."gcp_application_first_party_vulnerabilities" as __gcp_application_first_party_vulnerabilities_2
+        inner join "polymorphic"."gcp_applications" as __gcp_applications_2
+        on (
+          __gcp_applications_2."id" = __gcp_application_first_party_vulnerabilities_2."gcp_application_id"
+        )
+        inner join "polymorphic"."organizations" as __organizations_2
+        on (
+          __organizations_2."organization_id" = __gcp_applications_2."organization_id"
+        )
+        where __gcp_application_first_party_vulnerabilities_2."first_party_vulnerability_id" = __union_identifiers__."id3"
+        order by
+          __organizations_2."organization_id" asc
+      ) as __organizations_2
+    order by
+      "0" asc,
+      "n" asc
+  ) __owners__
+) as __union_result__;
+
+select __aws_applications_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __aws_applications_identifiers__,
+lateral (
+  select
+    __aws_applications__."id"::text as "0",
+    __aws_applications__."name" as "1",
+    __aws_applications__."person_id"::text as "2",
+    __aws_applications__."organization_id"::text as "3",
+    __aws_applications_identifiers__.idx as "4"
+  from "polymorphic"."aws_applications" as __aws_applications__
+  where (
+    __aws_applications__."id" = __aws_applications_identifiers__."id0"
+  )
+) as __aws_applications_result__;
+
+select __gcp_applications_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __gcp_applications_identifiers__,
+lateral (
+  select
+    __gcp_applications__."id"::text as "0",
+    __gcp_applications__."name" as "1",
+    __gcp_applications__."person_id"::text as "2",
+    __gcp_applications__."organization_id"::text as "3",
+    __gcp_applications_identifiers__.idx as "4"
+  from "polymorphic"."gcp_applications" as __gcp_applications__
+  where (
+    __gcp_applications__."id" = __gcp_applications_identifiers__."id0"
+  )
+) as __gcp_applications_result__;
+
+select __organizations_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __organizations_identifiers__,
+lateral (
+  select
+    __organizations__."organization_id"::text as "0",
+    __organizations__."name" as "1",
+    __organizations_identifiers__.idx as "2"
+  from "polymorphic"."organizations" as __organizations__
+  where (
+    __organizations__."organization_id" = __organizations_identifiers__."id0"
+  )
+) as __organizations_result__;
+
+select __people_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __people_identifiers__,
+lateral (
+  select
+    __people__."person_id"::text as "0",
+    __people__."username" as "1",
+    __people_identifiers__.idx as "2"
+  from "polymorphic"."people" as __people__
+  where (
+    __people__."person_id" = __people_identifiers__."id0"
+  )
+) as __people_result__;
+
+select __union_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0", (ids.value->>1)::"int4" as "id1" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+lateral (
+  select
+    __owner__."0" as "0",
+    __owner__."1"::text as "1",
+    __union_identifiers__.idx as "2"
+  from (
+      select
+        __people__."0",
+        __people__."1",
+        "n"
+      from (
+        select
+          'Person' as "0",
+          json_build_array((__people__."person_id")::text) as "1",
+          row_number() over (
+            order by
+              __people__."person_id" asc
+          ) as "n"
+        from "polymorphic"."people" as __people__
+        where __people__."person_id" = __union_identifiers__."id0"
+        order by
+          __people__."person_id" asc
+      ) as __people__
+    union all
+      select
+        __organizations__."0",
+        __organizations__."1",
+        "n"
+      from (
+        select
+          'Organization' as "0",
+          json_build_array((__organizations__."organization_id")::text) as "1",
+          row_number() over (
+            order by
+              __organizations__."organization_id" asc
+          ) as "n"
+        from "polymorphic"."organizations" as __organizations__
+        where __organizations__."organization_id" = __union_identifiers__."id1"
+        order by
+          __organizations__."organization_id" asc
+      ) as __organizations__
+    order by
+      "0" asc,
+      "n" asc
+  ) __owner__
+) as __union_result__;
+
+select __union_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0", (ids.value->>1)::"int4" as "id1" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+lateral (
+  select
+    __owner__."0" as "0",
+    __owner__."1"::text as "1",
+    __union_identifiers__.idx as "2"
+  from (
+      select
+        __people__."0",
+        __people__."1",
+        "n"
+      from (
+        select
+          'Person' as "0",
+          json_build_array((__people__."person_id")::text) as "1",
+          row_number() over (
+            order by
+              __people__."person_id" asc
+          ) as "n"
+        from "polymorphic"."people" as __people__
+        where __people__."person_id" = __union_identifiers__."id0"
+        order by
+          __people__."person_id" asc
+      ) as __people__
+    union all
+      select
+        __organizations__."0",
+        __organizations__."1",
+        "n"
+      from (
+        select
+          'Organization' as "0",
+          json_build_array((__organizations__."organization_id")::text) as "1",
+          row_number() over (
+            order by
+              __organizations__."organization_id" asc
+          ) as "n"
+        from "polymorphic"."organizations" as __organizations__
+        where __organizations__."organization_id" = __union_identifiers__."id1"
+        order by
+          __organizations__."organization_id" asc
+      ) as __organizations__
+    order by
+      "0" asc,
+      "n" asc
+  ) __owner__
+) as __union_result__;

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.test.graphql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.test.graphql
@@ -1,0 +1,52 @@
+## expect(errors).toBeFalsy()
+#> schema: ["polymorphic"]
+#> simpleCollections: "both"
+#> classicIds: true
+
+{
+  allVulnerabilities(first: 2) {
+    nodes {
+      id
+      name
+      applications {
+        nodes {
+          id
+          name
+          owner {
+            __typename
+            ...Owner
+          }
+        }
+      }
+      applicationsList {
+        id
+        name
+        owner {
+          __typename
+          ...Owner
+        }
+      }
+      owners {
+        nodes {
+          __typename
+          ...Owner
+        }
+      }
+      ownersList {
+        __typename
+        ...Owner
+      }
+    }
+  }
+}
+
+fragment Owner on PersonOrOrganization {
+  ... on Organization {
+    id
+    name
+  }
+  ... on Person {
+    id
+    username
+  }
+}

--- a/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.graphql
@@ -3321,11 +3321,16 @@ type Query implements Node {
   yieldById(id: Int!): Yield
 }
 
-interface RelationalItem {
+interface RelationalItem implements Node {
   """Reads a single `Building` that is related to this `RelationalItem`."""
   buildingByConstructor: Building
   constructor: String
   id: Int!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
   type: ItemType!
 }
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.graphql
@@ -1393,6 +1393,9 @@ type FirstPartyVulnerability implements Node & Vulnerability {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+
+  """Reads and enables pagination through a set of `PersonOrOrganization`."""
+  owners: PersonOrOrganizationConnection!
   teamName: String
 }
 
@@ -2655,6 +2658,29 @@ input PersonInput {
 }
 
 union PersonOrOrganization = Organization | Person
+
+"""A connection to a list of `PersonOrOrganization` values."""
+type PersonOrOrganizationConnection {
+  """
+  A list of edges which contains the `PersonOrOrganization` and cursor to aid in pagination.
+  """
+  edges: [PersonOrOrganizationEdge]!
+
+  """A list of `PersonOrOrganization` objects."""
+  nodes: [PersonOrOrganization]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+}
+
+"""A `PersonOrOrganization` edge in the connection."""
+type PersonOrOrganizationEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `PersonOrOrganization` at the end of the edge."""
+  node: PersonOrOrganization
+}
 
 """
 Represents an update to a `Person`. Fields that are set will be updated.
@@ -5267,6 +5293,9 @@ type ThirdPartyVulnerability implements Node & Vulnerability {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+
+  """Reads and enables pagination through a set of `PersonOrOrganization`."""
+  owners: PersonOrOrganizationConnection!
   vendorName: String
 }
 
@@ -6108,6 +6137,9 @@ interface Vulnerability implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+
+  """Reads and enables pagination through a set of `PersonOrOrganization`."""
+  owners: PersonOrOrganizationConnection!
 }
 
 """

--- a/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.graphql
@@ -1,7 +1,12 @@
-interface Application {
+interface Application implements Node {
   id: Int!
   lastDeployed: Datetime
   name: String!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 
   """
   Reads a single `PersonOrOrganization` that is related to this `Application`.
@@ -3394,6 +3399,48 @@ type Query implements Node {
   """Get a single `RelationalTopic`."""
   relationalTopicById(id: Int!): RelationalTopic
 
+  """Reads a single `SingleTableChecklist` using its globally unique `ID`."""
+  singleTableChecklist(
+    """
+    The globally unique `ID` to be used in selecting a single `SingleTableChecklist`.
+    """
+    nodeId: ID!
+  ): SingleTableChecklist
+
+  """
+  Reads a single `SingleTableChecklistItem` using its globally unique `ID`.
+  """
+  singleTableChecklistItem(
+    """
+    The globally unique `ID` to be used in selecting a single `SingleTableChecklistItem`.
+    """
+    nodeId: ID!
+  ): SingleTableChecklistItem
+
+  """Reads a single `SingleTableDivider` using its globally unique `ID`."""
+  singleTableDivider(
+    """
+    The globally unique `ID` to be used in selecting a single `SingleTableDivider`.
+    """
+    nodeId: ID!
+  ): SingleTableDivider
+
+  """Reads a single `SingleTablePost` using its globally unique `ID`."""
+  singleTablePost(
+    """
+    The globally unique `ID` to be used in selecting a single `SingleTablePost`.
+    """
+    nodeId: ID!
+  ): SingleTablePost
+
+  """Reads a single `SingleTableTopic` using its globally unique `ID`."""
+  singleTableTopic(
+    """
+    The globally unique `ID` to be used in selecting a single `SingleTableTopic`.
+    """
+    nodeId: ID!
+  ): SingleTableTopic
+
   """
   Reads a single `ThirdPartyVulnerability` using its globally unique `ID`.
   """
@@ -4068,12 +4115,17 @@ enum RelationalDividersOrderBy {
   UPDATED_AT_DESC
 }
 
-interface RelationalItem {
+interface RelationalItem implements Node {
   archivedAt: Datetime
   authorId: Int!
   createdAt: Datetime!
   id: Int!
   isExplicitlyArchived: Boolean!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
   parentId: Int
 
   """Reads a single `Person` that is related to this `RelationalItem`."""
@@ -4675,12 +4727,17 @@ enum RelationalTopicsOrderBy {
   UPDATED_AT_DESC
 }
 
-type SingleTableChecklist implements SingleTableItem {
+type SingleTableChecklist implements Node & SingleTableItem {
   archivedAt: Datetime
   authorId: Int!
   createdAt: Datetime!
   id: Int!
   isExplicitlyArchived: Boolean!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
   parentId: Int
 
   """Reads a single `Person` that is related to this `SingleTableItem`."""
@@ -4731,13 +4788,18 @@ type SingleTableChecklist implements SingleTableItem {
   updatedAt: Datetime!
 }
 
-type SingleTableChecklistItem implements SingleTableItem {
+type SingleTableChecklistItem implements Node & SingleTableItem {
   archivedAt: Datetime
   authorId: Int!
   createdAt: Datetime!
   description: String
   id: Int!
   isExplicitlyArchived: Boolean!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
   note: String
   parentId: Int
 
@@ -4792,13 +4854,18 @@ type SingleTableChecklistItem implements SingleTableItem {
   updatedAt: Datetime!
 }
 
-type SingleTableDivider implements SingleTableItem {
+type SingleTableDivider implements Node & SingleTableItem {
   archivedAt: Datetime
   authorId: Int!
   color: String
   createdAt: Datetime!
   id: Int!
   isExplicitlyArchived: Boolean!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
   parentId: Int
 
   """Reads a single `Person` that is related to this `SingleTableItem`."""
@@ -4849,12 +4916,17 @@ type SingleTableDivider implements SingleTableItem {
   updatedAt: Datetime!
 }
 
-interface SingleTableItem {
+interface SingleTableItem implements Node {
   archivedAt: Datetime
   authorId: Int!
   createdAt: Datetime!
   id: Int!
   isExplicitlyArchived: Boolean!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
   parentId: Int
 
   """Reads a single `Person` that is related to this `SingleTableItem`."""
@@ -4987,13 +5059,18 @@ enum SingleTableItemsOrderBy {
   UPDATED_AT_DESC
 }
 
-type SingleTablePost implements SingleTableItem {
+type SingleTablePost implements Node & SingleTableItem {
   archivedAt: Datetime
   authorId: Int!
   createdAt: Datetime!
   description: String
   id: Int!
   isExplicitlyArchived: Boolean!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
   note: String
   parentId: Int
 
@@ -5049,12 +5126,17 @@ type SingleTablePost implements SingleTableItem {
   updatedAt: Datetime!
 }
 
-type SingleTableTopic implements SingleTableItem {
+type SingleTableTopic implements Node & SingleTableItem {
   archivedAt: Datetime
   authorId: Int!
   createdAt: Datetime!
   id: Int!
   isExplicitlyArchived: Boolean!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
   parentId: Int
 
   """Reads a single `Person` that is related to this `SingleTableItem`."""
@@ -5997,7 +6079,7 @@ enum VulnerabilitiesOrderBy {
   NATURAL
 }
 
-interface Vulnerability {
+interface Vulnerability implements Node {
   """Reads and enables pagination through a set of `Application`."""
   applications(
     """Read all values in the set after (below) this cursor."""
@@ -6021,6 +6103,11 @@ interface Vulnerability {
   cvssScore: Float!
   id: Int!
   name: String!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """
@@ -6038,9 +6125,14 @@ input VulnerabilityCondition {
   name: String
 }
 
-interface ZeroImplementation {
+interface ZeroImplementation implements Node {
   id: Int
   name: String
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.graphql
@@ -1198,6 +1198,9 @@ type FirstPartyVulnerability implements Vulnerability {
   cvssScore: Float!
   id: Int!
   name: String!
+
+  """Reads and enables pagination through a set of `PersonOrOrganization`."""
+  owners: PersonOrOrganizationConnection!
   teamName: String
 }
 
@@ -2214,6 +2217,29 @@ input PersonInput {
 }
 
 union PersonOrOrganization = Organization | Person
+
+"""A connection to a list of `PersonOrOrganization` values."""
+type PersonOrOrganizationConnection {
+  """
+  A list of edges which contains the `PersonOrOrganization` and cursor to aid in pagination.
+  """
+  edges: [PersonOrOrganizationEdge]!
+
+  """A list of `PersonOrOrganization` objects."""
+  nodes: [PersonOrOrganization]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+}
+
+"""A `PersonOrOrganization` edge in the connection."""
+type PersonOrOrganizationEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `PersonOrOrganization` at the end of the edge."""
+  node: PersonOrOrganization
+}
 
 """
 Represents an update to a `Person`. Fields that are set will be updated.
@@ -4599,6 +4625,9 @@ type ThirdPartyVulnerability implements Vulnerability {
   cvssScore: Float!
   id: Int!
   name: String!
+
+  """Reads and enables pagination through a set of `PersonOrOrganization`."""
+  owners: PersonOrOrganizationConnection!
   vendorName: String
 }
 
@@ -5207,6 +5236,9 @@ interface Vulnerability {
   cvssScore: Float!
   id: Int!
   name: String!
+
+  """Reads and enables pagination through a set of `PersonOrOrganization`."""
+  owners: PersonOrOrganizationConnection!
 }
 
 """

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.graphql
@@ -1845,6 +1845,9 @@ type FirstPartyVulnerability implements Vulnerability {
     orderBy: [GcpApplicationFirstPartyVulnerabilityOrderBy!] = [PRIMARY_KEY_ASC]
   ): GcpApplicationFirstPartyVulnerabilityConnection!
   name: String!
+
+  """Reads and enables pagination through a set of `PersonOrOrganization`."""
+  owners: PersonOrOrganizationConnection!
   rowId: Int!
   teamName: String
 }
@@ -3265,6 +3268,29 @@ input PersonInput {
 }
 
 union PersonOrOrganization = Organization | Person
+
+"""A connection to a list of `PersonOrOrganization` values."""
+type PersonOrOrganizationConnection {
+  """
+  A list of edges which contains the `PersonOrOrganization` and cursor to aid in pagination.
+  """
+  edges: [PersonOrOrganizationEdge]!
+
+  """A list of `PersonOrOrganization` objects."""
+  nodes: [PersonOrOrganization]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+}
+
+"""A `PersonOrOrganization` edge in the connection."""
+type PersonOrOrganizationEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `PersonOrOrganization` at the end of the edge."""
+  node: PersonOrOrganization
+}
 
 """Methods to use when ordering `Person`."""
 enum PersonOrderBy {
@@ -5872,6 +5898,9 @@ type ThirdPartyVulnerability implements Vulnerability {
     orderBy: [GcpApplicationThirdPartyVulnerabilityOrderBy!] = [PRIMARY_KEY_ASC]
   ): GcpApplicationThirdPartyVulnerabilityConnection!
   name: String!
+
+  """Reads and enables pagination through a set of `PersonOrOrganization`."""
+  owners: PersonOrOrganizationConnection!
   rowId: Int!
   vendorName: String
 }
@@ -6699,6 +6728,9 @@ interface Vulnerability {
   ): ApplicationConnection!
   cvssScore: Float!
   name: String!
+
+  """Reads and enables pagination through a set of `PersonOrOrganization`."""
+  owners: PersonOrOrganizationConnection!
   rowId: Int!
 }
 

--- a/postgraphile/website/postgraphile/behavior.md
+++ b/postgraphile/website/postgraphile/behavior.md
@@ -157,8 +157,10 @@ PostGraphile/graphile-build/graphile-build-pg plugins utilise:
 - `nodeId:insert` - can we insert to the columns represented by this nodeId which represents a table related via foreign key constraint?
 - `nodeId:update` - can we update the columns represented by this nodeId which represents a table related via foreign key constraint?
 - `nodeId:base` - should we add a nodeId input representing this foreign key constraint to the "base" input type?
-- `node` - should this resource implement the GraphQL Global Object Identification
-  specification
+- `type:node` - should the GraphQLObjectType (`type`) this codec represents
+  implement the GraphQL Global Object Identification specification
+- `interface:node` - should the GraphQLInterfaceType (`interface`) this codec
+  represents implement the GraphQL Global Object Identification specification
 - `list` - list (simple collection)
 - `connection` - connection (GraphQL Cursor Pagination Spec)
 - `query:resource:list` - "list" field for a resource at the root Query level


### PR DESCRIPTION
This PR adds `Node` interface to `@interface mode:single`/`@interface mode:relational` if they have primary key - adds to both the interface and the types. Fixes https://github.com/graphile/postgraphile/issues/1740

If you were using `@interface mode:union` then you'll need to add `@behavior node` to the interface if you want it to have the `Node` interface still (this PR removes that).