### PR TITLE
Add rawClient to new NodePostgresPgClient subtype

### DIFF
--- a/.changeset/tidy-crabs-taste.md
+++ b/.changeset/tidy-crabs-taste.md
@@ -1,0 +1,10 @@
+---
+"graphile-build-pg": patch
+"@dataplan/pg": patch
+"postgraphile": patch
+---
+
+`@dataplan/pg/adaptors/pg` now adds `rawClient` property which is the underlying
+Postgres client for use with `pgTyped`, `zapatos`, and other libraries that can
+use a raw postgres client. This is exposed via `NodePostgresPgClient` interface
+which is a subtype of `PgClient`.

--- a/grafast/dataplan-pg/src/examples/exampleSchema.ts
+++ b/grafast/dataplan-pg/src/examples/exampleSchema.ts
@@ -78,7 +78,7 @@ import type {
   PgSelectStep,
   WithPgClient,
 } from "../";
-import type { PgSubscriber } from "../adaptors/pg.js";
+import type { NodePostgresPgClient, PgSubscriber } from "../adaptors/pg.js";
 import { listOfCodec } from "../codecs.js";
 import {
   makePgResourceOptions,
@@ -143,7 +143,7 @@ export function EXPORTABLE<T, TScope extends any[]>(
 // This is the actual runtime context; we should not use a global for this.
 export interface OurGraphQLContext extends Grafast.Context {
   pgSettings: { [key: string]: string };
-  withPgClient: WithPgClient;
+  withPgClient: WithPgClient<NodePostgresPgClient>;
   pgSubscriber: PgSubscriber;
 }
 

--- a/grafast/dataplan-pg/src/executor.ts
+++ b/grafast/dataplan-pg/src/executor.ts
@@ -76,23 +76,29 @@ export interface PgClient {
   withTransaction<T>(callback: (client: PgClient) => Promise<T>): Promise<T>;
 }
 
-export interface WithPgClient {
+export interface WithPgClient<TPgClient extends PgClient = PgClient> {
   <T>(
     pgSettings: { [key: string]: string } | null,
-    callback: (client: PgClient) => T | Promise<T>,
+    callback: (client: TPgClient) => T | Promise<T>,
   ): Promise<T>;
 
   release?(): PromiseOrDirect<void>;
 }
 
-export type PgExecutorContext<TSettings = any> = {
+export type PgExecutorContext<
+  TSettings = any,
+  TPgClient extends PgClient = PgClient,
+> = {
   pgSettings: TSettings;
-  withPgClient: WithPgClient;
+  withPgClient: WithPgClient<TPgClient>;
 };
 
-export type PgExecutorContextPlans<TSettings = any> = {
+export type PgExecutorContextPlans<
+  TSettings = any,
+  TPgClient extends PgClient = PgClient,
+> = {
   pgSettings: ExecutableStep<TSettings>;
-  withPgClient: ExecutableStep<WithPgClient>;
+  withPgClient: ExecutableStep<WithPgClient<TPgClient>>;
 };
 
 export type PgExecutorInput<TInput> = {

--- a/graphile-build/graphile-build-pg/src/examples/NO_DATA_GATHERING.ts
+++ b/graphile-build/graphile-build-pg/src/examples/NO_DATA_GATHERING.ts
@@ -37,17 +37,6 @@ import sql from "pg-sql2";
 
 import { defaultPreset as graphileBuildPgPreset } from "../index.js";
 
-declare global {
-  namespace Grafast {
-    interface Context {
-      pgSettings: {
-        [key: string]: string;
-      } | null;
-      withPgClient: WithPgClient;
-    }
-  }
-}
-
 const pool = new Pool({
   connectionString: "pggql_test",
 });

--- a/graphile-build/graphile-build-pg/src/examples/benjies-test-script.ts
+++ b/graphile-build/graphile-build-pg/src/examples/benjies-test-script.ts
@@ -42,17 +42,6 @@ import * as ws from "ws";
 import { defaultPreset as graphileBuildPgPreset } from "../index.js";
 import { getWithPgClientFromPgService } from "../pgServices.js";
 
-declare global {
-  namespace Grafast {
-    interface Context {
-      pgSettings: {
-        [key: string]: string;
-      } | null;
-      withPgClient: WithPgClient;
-    }
-  }
-}
-
 const pool = new Pool({
   connectionString: "pggql_test",
 });

--- a/graphile-build/graphile-build-pg/src/examples/benjies-test-script.ts
+++ b/graphile-build/graphile-build-pg/src/examples/benjies-test-script.ts
@@ -9,7 +9,6 @@
  * query.
  */
 
-import type { WithPgClient } from "@dataplan/pg";
 import { envelop, useExtendContext, useSchema } from "@envelop/core";
 import { useParserCache } from "@envelop/parser-cache";
 import { useValidationCache } from "@envelop/validation-cache";

--- a/graphile-build/graphile-build-pg/src/examples/config.ts
+++ b/graphile-build/graphile-build-pg/src/examples/config.ts
@@ -6,7 +6,6 @@
 
 import "graphile-config";
 
-import type { WithPgClient } from "@dataplan/pg";
 import {
   defaultPreset as graphileBuildPreset,
   QueryQueryPlugin,
@@ -26,17 +25,6 @@ const DATABASE_SCHEMAS: string[] = ["public", "app_public"];
 /* **         BELOW HERE IS WHERE THE CODE LIVES, ABOVE IS CONFIG          ** */
 /* **                                                                      ** */
 /* ************************************************************************** */
-
-declare global {
-  namespace Grafast {
-    interface Context {
-      pgSettings: {
-        [key: string]: string;
-      } | null;
-      withPgClient: WithPgClient;
-    }
-  }
-}
 
 export function getPool() {
   const pool = new Pool({

--- a/graphile-build/graphile-build-pg/src/examples/webpack.ts
+++ b/graphile-build/graphile-build-pg/src/examples/webpack.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-restricted-syntax */
 
-import type { WithPgClient } from "@dataplan/pg";
 import {
   buildInflection,
   buildSchema,
@@ -20,18 +19,6 @@ import { defaultPreset as graphileBuildPgPreset } from "../index.js";
  * Set this to 'false' for production and the bundle will be minified.
  */
 const DEBUG_MODE = true;
-
-// Our server will supply pgSettings/withPgClient on the GraphQL context
-declare global {
-  namespace Grafast {
-    interface Context {
-      pgSettings: {
-        [key: string]: string;
-      } | null;
-      withPgClient: WithPgClient;
-    }
-  }
-}
 
 // Create a pool and add the error handler
 const pool = new Pool({


### PR DESCRIPTION
So the `pgClient` you get from `withPgClient`/`withPgClientTransaction` now has a `.rawClient` property you can use to get the underlying client from the `pg` module. This should allow you to use the `@dataplan/pg/adaptors/pg` adaptor with `pgTyped` and similar libraries:

```ts
const $books = withPgClient(executor, constant(null), async (pgClient) => {
  const books = await findBookById.run(
    { bookId: 5 },
    pgClient.rawClient, // < Don't forget to access .rawClient!
  );
  return books;
});
```