### PR TITLE
Improve errors; forbid a bad pattern

### DIFF
--- a/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
@@ -1368,8 +1368,9 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
               } else if (codec.domainOfCodec) {
                 // We just want to be a copy of the underlying type spec, but with a different name/description
                 const copy = (underlyingTypeName: string) => (): any => {
-                  const baseType = build.getTypeByName(underlyingTypeName);
-                  const config = { ...baseType?.toConfig() };
+                  const details = build.getTypeMetaByName(underlyingTypeName);
+                  const baseConfig = details?.specGenerator();
+                  const config = { ...baseConfig };
                   delete (config as any).name;
                   delete (config as any).description;
                   return config;

--- a/graphile-build/graphile-build-pg/src/plugins/PgCustomTypeFieldPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCustomTypeFieldPlugin.ts
@@ -689,40 +689,40 @@ export const PgCustomTypeFieldPlugin: GraphileConfig.Plugin = {
                     inputTypeName,
                     { isMutationInput: true },
                     () => {
-                      const { argDetails } = pgGetArgDetailsFromParameters(
-                        resource,
-                        resource.parameters,
-                      );
-
-                      // Not used for isMutation; that's handled elsewhere
-                      const fields = argDetails.reduce(
-                        (memo, { inputType, graphqlArgName }) => {
-                          memo[graphqlArgName] = {
-                            type: inputType,
-                          };
-                          return memo;
-                        },
-                        Object.assign(Object.create(null), {
-                          clientMutationId: {
-                            type: GraphQLString,
-                            autoApplyAfterParentApplyPlan: true,
-                            applyPlan: EXPORTABLE(
-                              () =>
-                                function plan(
-                                  $input: ObjectStep<any>,
-                                  val: FieldArgs,
-                                ) {
-                                  $input.set("clientMutationId", val.get());
-                                },
-                              [],
-                            ),
-                          },
-                        }) as GrafastInputFieldConfigMap<any, any>,
-                      );
-
                       return {
                         description: `All input for the \`${fieldName}\` mutation.`,
-                        fields,
+                        fields: () => {
+                          const { argDetails } = pgGetArgDetailsFromParameters(
+                            resource,
+                            resource.parameters,
+                          );
+
+                          // Not used for isMutation; that's handled elsewhere
+                          return argDetails.reduce(
+                            (memo, { inputType, graphqlArgName }) => {
+                              memo[graphqlArgName] = {
+                                type: inputType,
+                              };
+                              return memo;
+                            },
+                            Object.assign(Object.create(null), {
+                              clientMutationId: {
+                                type: GraphQLString,
+                                autoApplyAfterParentApplyPlan: true,
+                                applyPlan: EXPORTABLE(
+                                  () =>
+                                    function plan(
+                                      $input: ObjectStep<any>,
+                                      val: FieldArgs,
+                                    ) {
+                                      $input.set("clientMutationId", val.get());
+                                    },
+                                  [],
+                                ),
+                              },
+                            }) as GrafastInputFieldConfigMap<any, any>,
+                          );
+                        },
                       };
                     },
                     "PgCustomTypeFieldPlugin mutation function input type",

--- a/graphile-build/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.ts
@@ -517,7 +517,7 @@ export const PgMutationUpdateDeletePlugin: GraphileConfig.Plugin = {
                                 Object.create(null),
                               )),
                         },
-                        mode === "resource:update"
+                        mode === "resource:update" && TablePatch
                           ? {
                               [inflection.patchField(
                                 inflection.tableFieldName(resource),

--- a/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismPlugin.ts
@@ -262,7 +262,13 @@ export const PgPolymorphismPlugin: GraphileConfig.Plugin = {
                   );
                 if (!pgConstraint) {
                   throw new Error(
-                    "Could not build polymorphic reference due to missing foreign key constraint",
+                    `Could not build polymorphic reference from '${
+                      pgClass.getNamespace()?.nspname
+                    }.${pgClass.relname}' to '${
+                      referencedClass.getNamespace()?.nspname
+                    }.${
+                      referencedClass.relname
+                    }' due to missing foreign key constraint. Please create a foreign key constraint on the latter table's primary key, pointing to the former table.`,
                   );
                 }
                 const codec = await info.helpers.pgCodecs.getCodecFromClass(

--- a/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismPlugin.ts
@@ -844,7 +844,7 @@ export const PgPolymorphismPlugin: GraphileConfig.Plugin = {
                       () => ({
                         assertStep: assertPgClassSingleStep,
                         description: codec.description,
-                        interfaces: [
+                        interfaces: () => [
                           build.getTypeByName(
                             interfaceTypeName,
                           ) as GraphQLInterfaceType,

--- a/graphile-build/graphile-build-pg/src/plugins/PgTypesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTypesPlugin.ts
@@ -474,7 +474,7 @@ export const PgTypesPlugin: GraphileConfig.Plugin = {
                 "An interval of time that has passed where the smallest distinct unit is a second.",
                 "type",
               ),
-              fields: makeIntervalFields(),
+              fields: () => makeIntervalFields(),
             }),
             "graphile-build-pg built-in (Interval)",
           );
@@ -488,7 +488,7 @@ export const PgTypesPlugin: GraphileConfig.Plugin = {
                 "An interval of time that has passed where the smallest distinct unit is a second.",
                 "type",
               ),
-              fields: makeIntervalFields(),
+              fields: () => makeIntervalFields(),
             }),
             "graphile-build-pg built-in (IntervalInput)",
           );
@@ -505,7 +505,7 @@ export const PgTypesPlugin: GraphileConfig.Plugin = {
               () => ({
                 assertStep: null, // TODO: does this want a plan?
                 description: build.wrapDescription(description, "type"),
-                fields: fieldGen(),
+                fields: () => fieldGen(),
               }),
               `graphile-build-pg built-in (${typeName})`,
             );
@@ -515,7 +515,7 @@ export const PgTypesPlugin: GraphileConfig.Plugin = {
               { [`isPg${typeName}InputType`]: true },
               () => ({
                 description: build.wrapDescription(description, "type"),
-                fields: inputFieldGen(),
+                fields: () => inputFieldGen(),
               }),
               `graphile-build-pg built-in (${typeName}Input)`,
             );

--- a/graphile-build/graphile-build/src/global.ts
+++ b/graphile-build/graphile-build/src/global.ts
@@ -422,6 +422,16 @@ declare global {
         scope: GraphileBuild.SomeScope;
         origin: string | null | undefined;
         Step?: { new (...args: any[]): ExecutableStep } | null;
+        specGenerator:
+          | (() => Omit<
+              GraphileBuild.GrafastObjectTypeConfig<any, any>,
+              "name"
+            >)
+          | (() => Omit<GrafastInterfaceTypeConfig<any, any>, "name">)
+          | (() => Omit<GrafastUnionTypeConfig<any, any>, "name">)
+          | (() => Omit<GraphQLScalarTypeConfig<any, any>, "name">)
+          | (() => Omit<GraphQLEnumTypeConfig, "name">)
+          | (() => Omit<GrafastInputObjectTypeConfig, "name">);
       } | null;
 
       /**

--- a/graphile-build/graphile-build/src/makeNewBuild.ts
+++ b/graphile-build/graphile-build/src/makeNewBuild.ts
@@ -25,9 +25,20 @@ import extend, { indent } from "./extend.js";
 import type SchemaBuilder from "./SchemaBuilder.js";
 import { EXPORTABLE, stringTypeSpec, wrapDescription } from "./utils.js";
 import { version } from "./version.js";
+import { inspect } from "node:util";
 
 /** Have we warned the user they're using the 5-arg deprecated registerObjectType call? */
 let registerObjectType5argsDeprecatedWarned = false;
+
+/** @internal */
+interface TypeDetails {
+  typeName: string;
+  // The constructor - GraphQLScalarType, GraphQLObjectType, etc
+  klass: { new (spec: any): GraphQLNamedType };
+  scope: GraphileBuild.SomeScope;
+  specGenerator: any;
+  origin: string | null | undefined;
+}
 
 /**
  * Makes a new 'Build' object suitable to be passed through the 'build' hook.
@@ -58,13 +69,7 @@ export default function makeNewBuild(
    * Where the type factories are; so we don't construct types until they're needed.
    */
   const typeRegistry: {
-    [key: string]: {
-      // The constructor - GraphQLScalarType, GraphQLObjectType, etc
-      klass: { new (spec: any): GraphQLNamedType };
-      scope: GraphileBuild.SomeScope;
-      specGenerator: any;
-      origin: string | null | undefined;
-    };
+    [key: string]: TypeDetails;
   } = Object.create(null);
 
   const scopeByType = new Map<GraphQLNamedType, GraphileBuild.SomeScope>();
@@ -106,6 +111,7 @@ export default function makeNewBuild(
     }
     allTypesSources[typeName] = newTypeSource;
     typeRegistry[typeName] = {
+      typeName,
       klass,
       scope,
       specGenerator,
@@ -319,6 +325,15 @@ export default function makeNewBuild(
     },
 
     getTypeByName(typeName) {
+      if (currentTypeDetails) {
+        throw new Error(
+          `Error in spec callback for ${currentTypeDetails.klass.name} '${
+            currentTypeDetails.typeName
+          }'; the callback made a call to \`build.getTypeByName(${JSON.stringify(
+            typeName,
+          )})\` (directly or indirectly) - this is the wrong time for such a call to occur since it can lead to circular dependence. Most likely you need to check the callback function, and move any calls to 'getTypeByName' (or similar) into one of the spec object's callbacks, such as \`fields()\`, \`interfaces()\` or similar.`,
+        );
+      }
       if (!this.status.isInitPhaseComplete) {
         throw new Error(
           "Must not call build.getTypeByName before 'init' phase is complete",
@@ -328,16 +343,20 @@ export default function makeNewBuild(
         return allTypes[typeName];
       } else if (building.has(typeName)) {
         throw new Error(
-          `Construction cycle detected: ${typeName} is already being built. Most likely this means that you forgot to use a callback for 'fields', 'interfaces', 'types', etc. when defining a type.`,
+          `Construction cycle detected: ${typeName} is already being built (build stack: ${[
+            ...building,
+          ].join(
+            ">",
+          )}). Most likely this means that you forgot to use a callback for 'fields', 'interfaces', 'types', etc. when defining a type.`,
         );
       } else {
         building.add(typeName);
         try {
           const details = typeRegistry[typeName];
           if (details != null) {
-            const { klass, scope, specGenerator } = details;
+            const { klass, scope } = details;
 
-            const spec = specGenerator();
+            const spec = generateSpecFromDetails(details);
             // No need to have the user specify name, and they're forbidden from
             // changing name (use inflection instead!) so we just set it
             // ourselves:
@@ -449,4 +468,15 @@ export default function makeNewBuild(
     _pluginMeta: Object.create(null),
   };
   return build;
+}
+
+let currentTypeDetails: TypeDetails | null = null;
+
+function generateSpecFromDetails(details: TypeDetails) {
+  currentTypeDetails = details;
+  try {
+    return details.specGenerator();
+  } finally {
+    currentTypeDetails = null;
+  }
 }

--- a/graphile-build/graphile-build/src/plugins/ConnectionPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/ConnectionPlugin.ts
@@ -155,92 +155,94 @@ export const ConnectionPlugin: GraphileConfig.Plugin = {
                   isConnectionType: true,
                 },
                 () => {
-                  const NodeType = build.getOutputTypeByName(typeName);
-                  const EdgeType = build.getOutputTypeByName(edgeTypeName);
-                  const PageInfo = build.getOutputTypeByName(
-                    build.inflection.builtin("PageInfo"),
-                  );
                   return {
                     assertStep: ConnectionStep,
                     description: build.wrapDescription(
                       `A connection to a list of \`${typeName}\` values.`,
                       "type",
                     ),
-                    fields: ({ fieldWithHooks }) => ({
-                      nodes: fieldWithHooks(
-                        {
-                          fieldName: "nodes",
-                        },
-                        () => ({
-                          description: build.wrapDescription(
-                            `A list of \`${typeName}\` objects.`,
-                            "field",
-                          ),
-                          type: new build.graphql.GraphQLNonNull(
-                            new build.graphql.GraphQLList(
-                              nullableIf(!nonNullNode, NodeType),
+                    fields: ({ fieldWithHooks }) => {
+                      const NodeType = build.getOutputTypeByName(typeName);
+                      const EdgeType = build.getOutputTypeByName(edgeTypeName);
+                      const PageInfo = build.getOutputTypeByName(
+                        build.inflection.builtin("PageInfo"),
+                      );
+                      return {
+                        nodes: fieldWithHooks(
+                          {
+                            fieldName: "nodes",
+                          },
+                          () => ({
+                            description: build.wrapDescription(
+                              `A list of \`${typeName}\` objects.`,
+                              "field",
                             ),
-                          ),
-                          plan: EXPORTABLE(
-                            () =>
-                              function plan(
-                                $connection: ConnectionStep<any, any, any>,
-                              ) {
-                                return $connection.nodes();
-                              },
-                            [],
-                          ) as any,
-                        }),
-                      ),
-                      edges: fieldWithHooks(
-                        {
-                          fieldName: "edges",
-                        },
-                        () => ({
-                          description: build.wrapDescription(
-                            `A list of edges which contains the \`${typeName}\` and cursor to aid in pagination.`,
-                            "field",
-                          ),
-                          type: nullableIf(
-                            false,
-                            new build.graphql.GraphQLList(
-                              nullableIf(!nonNullNode, EdgeType),
+                            type: new build.graphql.GraphQLNonNull(
+                              new build.graphql.GraphQLList(
+                                nullableIf(!nonNullNode, NodeType),
+                              ),
                             ),
-                          ),
-                          plan: EXPORTABLE(
-                            () =>
-                              function plan(
-                                $connection: ConnectionStep<any, any, any>,
-                              ) {
-                                return $connection.edges();
-                              },
-                            [],
-                          ) as any,
-                        }),
-                      ),
-                      pageInfo: fieldWithHooks(
-                        {
-                          fieldName: "pageInfo",
-                        },
-                        () => ({
-                          description: build.wrapDescription(
-                            "Information to aid in pagination.",
-                            "field",
-                          ),
-                          type: new build.graphql.GraphQLNonNull(PageInfo),
-                          plan: EXPORTABLE(
-                            () =>
-                              function plan(
-                                $connection: ConnectionStep<any, any, any>,
-                              ) {
-                                // TYPES: why is this a TypeScript issue without the 'any'?
-                                return $connection.pageInfo() as any;
-                              },
-                            [],
-                          ),
-                        }),
-                      ),
-                    }),
+                            plan: EXPORTABLE(
+                              () =>
+                                function plan(
+                                  $connection: ConnectionStep<any, any, any>,
+                                ) {
+                                  return $connection.nodes();
+                                },
+                              [],
+                            ) as any,
+                          }),
+                        ),
+                        edges: fieldWithHooks(
+                          {
+                            fieldName: "edges",
+                          },
+                          () => ({
+                            description: build.wrapDescription(
+                              `A list of edges which contains the \`${typeName}\` and cursor to aid in pagination.`,
+                              "field",
+                            ),
+                            type: nullableIf(
+                              false,
+                              new build.graphql.GraphQLList(
+                                nullableIf(!nonNullNode, EdgeType),
+                              ),
+                            ),
+                            plan: EXPORTABLE(
+                              () =>
+                                function plan(
+                                  $connection: ConnectionStep<any, any, any>,
+                                ) {
+                                  return $connection.edges();
+                                },
+                              [],
+                            ) as any,
+                          }),
+                        ),
+                        pageInfo: fieldWithHooks(
+                          {
+                            fieldName: "pageInfo",
+                          },
+                          () => ({
+                            description: build.wrapDescription(
+                              "Information to aid in pagination.",
+                              "field",
+                            ),
+                            type: new build.graphql.GraphQLNonNull(PageInfo),
+                            plan: EXPORTABLE(
+                              () =>
+                                function plan(
+                                  $connection: ConnectionStep<any, any, any>,
+                                ) {
+                                  // TYPES: why is this a TypeScript issue without the 'any'?
+                                  return $connection.pageInfo() as any;
+                                },
+                              [],
+                            ),
+                          }),
+                        ),
+                      };
+                    },
                   };
                 },
                 `ConnectionPlugin connection type for ${typeName}`,

--- a/postgraphile/postgraphile/src/plugins/PgV4SmartTagsPlugin.ts
+++ b/postgraphile/postgraphile/src/plugins/PgV4SmartTagsPlugin.ts
@@ -88,7 +88,7 @@ function processTags(
   processOmit(tags);
   convertBoolean(tags, "sortable", "orderBy order");
   convertBoolean(tags, "filterable", "filter filterBy");
-  convertBoolean(tags, "enum", "enum");
+  // convertBoolean(tags, "enum", "enum");
   processSimpleCollections(tags);
 }
 


### PR DESCRIPTION
Calling `getTypeByName` directly or indirectly inside a type generator function is not allowed:

```ts
// BAD!
registerObjectType(
  'Foo',
  {},
  () => {
    const Bar = getTypeByName('Bar');
    return {
      fields: {
        bar: {
          type: Bar
        }
      }
    }
  },
  ''
);
```

it can only be called from within callbacks that that spec contains:

```ts
// Fine
registerObjectType(
  'Foo',
  {},
  () => {
    return {
      fields() {
        const Bar = getTypeByName('Bar');
        return {
          bar: {
            type: Bar
          }
        };
      }
    }
  },
  ''
);
```

The reason for this is it has the potential to trigger hard to debug and hard to reproduce cycles.

This PR enforces this rule by throwing if `getTypeByName` is called again when `getTypeByName` is currently running. This found the problem in 5 places in the core codebase, so I wouldn't be surprised if it also found issues with plugins. However, it's a net win because it should completely eradicate this class of error.

Thanks to @andreyobrezkov for bringing this to my attention.