### PR TITLE
Update make-extend-schema-plugin.md

### DIFF
--- a/postgraphile/website/postgraphile/migrating-from-v4/make-extend-schema-plugin.md
+++ b/postgraphile/website/postgraphile/migrating-from-v4/make-extend-schema-plugin.md
@@ -137,8 +137,8 @@ in JS, you might use an SQL expression:
 +    plans: {
 +      User: {
 +        nameWithSuffix($user, { $suffix }) {
-+          return $user.expression(
-+            sql`${$user.alias}.name || ' ' || ${$user.placeholder($suffix, TYPES.text)}`,
++          return $user.select(
++            sql`${$user.getClassStep().alias}.name || ' ' || ${$user.placeholder($suffix, TYPES.text)}`,
 +            TYPES.text,
 +          );
 +        }


### PR DESCRIPTION
I think `.expression()` doesn't exists anymore and I think `.select()` is the correct way.

I'm unsure if you need todo `$user.getClassStep().alias` and `$user.placeholder($suffix, TYPES.text)`.
Edit: Tested this and it seems to work.

