### PR TITLE
Send GraphQLError to client during processGraphQLRequestBody hook

### DIFF
--- a/grafast/grafserv/src/utils.ts
+++ b/grafast/grafserv/src/utils.ts
@@ -181,7 +181,7 @@ export function httpError(statusCode: number, message: string): SafeError {
 export function makeGraphQLWSConfig(instance: GrafservBase): ServerOptions {
   const {
     resolvedPreset,
-    dynamicOptions: { maskExecutionResult },
+    dynamicOptions: { maskError, maskExecutionResult },
   } = instance;
 
   const hooks = getGrafservHooks(resolvedPreset);
@@ -263,14 +263,16 @@ export function makeGraphQLWSConfig(instance: GrafservBase): ServerOptions {
         return args;
       } catch (e) {
         return [
-          new GraphQLError(
-            e.message,
-            null,
-            undefined,
-            undefined,
-            undefined,
-            e,
-            undefined,
+          maskError(
+            new GraphQLError(
+              e.message,
+              null,
+              undefined,
+              undefined,
+              undefined,
+              e,
+              undefined,
+            ),
           ),
         ];
       }

--- a/grafast/grafserv/src/utils.ts
+++ b/grafast/grafserv/src/utils.ts
@@ -193,89 +193,87 @@ export function makeGraphQLWSConfig(instance: GrafservBase): ServerOptions {
 
   return {
     async onSubscribe(ctx, message) {
-      // Get up to date schema, in case we're in watch mode
-      const schemaOrPromise = instance.getSchema();
-      if (schemaOrPromise !== latestSchemaOrPromise) {
-        if ("then" in schemaOrPromise) {
-          latestSchemaOrPromise = schemaOrPromise;
-          schemaPrepare = (async () => {
-            latestSchema = await schemaOrPromise;
+      try {
+        // Get up to date schema, in case we're in watch mode
+        const schemaOrPromise = instance.getSchema();
+        if (schemaOrPromise !== latestSchemaOrPromise) {
+          if ("then" in schemaOrPromise) {
             latestSchemaOrPromise = schemaOrPromise;
-            latestParseAndValidate = makeParseAndValidateFunction(latestSchema);
-            schemaPrepare = null;
-            return true;
-          })();
-        } else {
-          latestSchemaOrPromise = schemaOrPromise;
-          if (latestSchema === schemaOrPromise) {
-            // No action necessary
+            schemaPrepare = (async () => {
+              latestSchema = await schemaOrPromise;
+              latestSchemaOrPromise = schemaOrPromise;
+              latestParseAndValidate =
+                makeParseAndValidateFunction(latestSchema);
+              schemaPrepare = null;
+              return true;
+            })();
           } else {
-            latestSchema = schemaOrPromise;
-            latestParseAndValidate = makeParseAndValidateFunction(latestSchema);
+            latestSchemaOrPromise = schemaOrPromise;
+            if (latestSchema === schemaOrPromise) {
+              // No action necessary
+            } else {
+              latestSchema = schemaOrPromise;
+              latestParseAndValidate =
+                makeParseAndValidateFunction(latestSchema);
+            }
           }
         }
-      }
-      if (schemaPrepare !== null) {
-        const schemaReady = await Promise.race([
-          schemaPrepare,
-          sleep(instance.dynamicOptions.schemaWaitTime),
-        ]);
-        if (schemaReady !== true) {
-          // Handle missing schema
-          throw new Error(`Schema isn't ready`);
+        if (schemaPrepare !== null) {
+          const schemaReady = await Promise.race([
+            schemaPrepare,
+            sleep(instance.dynamicOptions.schemaWaitTime),
+          ]);
+          if (schemaReady !== true) {
+            // Handle missing schema
+            throw new Error(`Schema isn't ready`);
+          }
         }
-      }
-      const schema = latestSchema;
-      const parseAndValidate = latestParseAndValidate;
+        const schema = latestSchema;
+        const parseAndValidate = latestParseAndValidate;
 
-      const parsedBody = parseGraphQLJSONBody(message.payload);
-      try {
+        const parsedBody = parseGraphQLJSONBody(message.payload);
         await hooks.process("processGraphQLRequestBody", {
           body: parsedBody,
           graphqlWsContext: ctx,
         });
-      } catch (e) {
-        if (e instanceof SafeError) {
-          return  [
-              new GraphQLError(
-                e.message,
-                null,
-                undefined,
-                undefined,
-                undefined,
-                e,
-                undefined,
-              ),
-            ]
-        } else {
-          throw e;
+
+        const { query, operationName, variableValues } =
+          validateGraphQLBody(parsedBody);
+        const { errors, document } = parseAndValidate(query);
+        if (errors !== undefined) {
+          return errors;
         }
+        const args: ExecutionArgs = {
+          schema,
+          document,
+          rootValue: null,
+          contextValue: Object.create(null),
+          variableValues,
+          operationName,
+        };
+
+        await hookArgs(args, resolvedPreset, {
+          ws: {
+            request: (ctx.extra as Extra).request,
+            socket: (ctx.extra as Extra).socket,
+            connectionParams: ctx.connectionParams,
+          },
+        });
+
+        return args;
+      } catch (e) {
+        return [
+          new GraphQLError(
+            e.message,
+            null,
+            undefined,
+            undefined,
+            undefined,
+            e,
+            undefined,
+          ),
+        ];
       }
-
-      const { query, operationName, variableValues } =
-        validateGraphQLBody(parsedBody);
-      const { errors, document } = parseAndValidate(query);
-      if (errors !== undefined) {
-        return errors;
-      }
-      const args: ExecutionArgs = {
-        schema,
-        document,
-        rootValue: null,
-        contextValue: Object.create(null),
-        variableValues,
-        operationName,
-      };
-
-      await hookArgs(args, resolvedPreset, {
-        ws: {
-          request: (ctx.extra as Extra).request,
-          socket: (ctx.extra as Extra).socket,
-          connectionParams: ctx.connectionParams,
-        },
-      });
-
-      return args;
     },
     async execute(args: ExecutionArgs) {
       return maskExecutionResult(await execute(args, resolvedPreset));

--- a/grafast/grafserv/src/utils.ts
+++ b/grafast/grafserv/src/utils.ts
@@ -236,8 +236,7 @@ export function makeGraphQLWSConfig(instance: GrafservBase): ServerOptions {
         });
       } catch (e) {
         if (e instanceof SafeError) {
-          return {
-            errors: [
+          return  [
               new GraphQLError(
                 e.message,
                 null,
@@ -247,8 +246,7 @@ export function makeGraphQLWSConfig(instance: GrafservBase): ServerOptions {
                 e,
                 undefined,
               ),
-            ],
-          };
+            ]
         } else {
           throw e;
         }


### PR DESCRIPTION
If a SafeError is raised in the execution of the `GraphQLProcessRequestBody` hook, this error must be returned to the client (web request or ws subscription), as well as stopping the query execution flow.
Especially in subscription-ws, where the connection is closed abruptly.