### PR TITLE
Experimental ws for H3Grafserv

### DIFF
--- a/grafast/grafserv/src/servers/h3/v1/index.ts
+++ b/grafast/grafserv/src/servers/h3/v1/index.ts
@@ -83,13 +83,13 @@ export class H3Grafserv extends GrafservBase {
   }
 
   /**
-   * @deprecated use handleGraphqlEvent instead
+   * @deprecated use handleGraphQLEvent instead
    */
   public async handleEvent(event: H3Event) {
-    return this.handleGraphqlEvent(event);
+    return this.handleGraphQLEvent(event);
   }
 
-  public async handleGraphqlEvent(event: H3Event) {
+  public async handleGraphQLEvent(event: H3Event) {
     const digest = getDigest(event);
 
     const handlerResult = await this.graphqlHandler(

--- a/grafast/grafserv/src/servers/h3/v1/index.ts
+++ b/grafast/grafserv/src/servers/h3/v1/index.ts
@@ -220,7 +220,7 @@ export class H3Grafserv extends GrafservBase {
 
     router.use(
       this.dynamicOptions.graphqlPath,
-      eventHandler(this.handleEvent),
+      eventHandler((event) => this.handleGraphqlEvent(event)),
       this.dynamicOptions.graphqlOverGET ||
         this.dynamicOptions.graphiqlOnGraphQLGET
         ? ["get", "post"]
@@ -230,14 +230,14 @@ export class H3Grafserv extends GrafservBase {
     if (dynamicOptions.graphiql) {
       router.get(
         this.dynamicOptions.graphiqlPath,
-        eventHandler(this.handleGraphiqlEvent),
+        eventHandler((event) => this.handleGraphiqlEvent(event)),
       );
     }
 
     if (dynamicOptions.watch) {
       router.get(
         this.dynamicOptions.eventStreamPath,
-        eventHandler(this.handleEventStreamEvent),
+        eventHandler((event) => this.handleEventStreamEvent(event)),
       );
     }
   }

--- a/grafast/grafserv/src/servers/h3/v1/index.ts
+++ b/grafast/grafserv/src/servers/h3/v1/index.ts
@@ -220,7 +220,7 @@ export class H3Grafserv extends GrafservBase {
 
     router.use(
       this.dynamicOptions.graphqlPath,
-      eventHandler((event) => this.handleGraphqlEvent(event)),
+      eventHandler((event) => this.handleGraphQLEvent(event)),
       this.dynamicOptions.graphqlOverGET ||
         this.dynamicOptions.graphiqlOnGraphQLGET
         ? ["get", "post"]


### PR DESCRIPTION
This PR add :
- bump to h3@1.8.1
- replace `getMethod` (deprecated in h3@1.8.1) with `event.method`
- `handleEvent`, `handleGraphiqlEvent` and `handleEventStreamEvent` helpers (for using with nuxt3)
- `addTo` to H3Grafserv (for using with h3 as standalone),
- add an experimental `H3Grafserv` (when importing via `server/h3/v1/experimental') for implements subsciption-ws for h3 (or nuxt3)