### PR TITLE
Add apostrophes for possesives in plan-resolvers.md

### DIFF
--- a/grafast/website/grafast/plan-resolvers.md
+++ b/grafast/website/grafast/plan-resolvers.md
@@ -68,7 +68,7 @@ function plan_resolver(
 
 :::note
 
-By convention, when a variable represents a step we start the variables name
+By convention, when a variable represents a step we start the variable's name
 with a `$`.
 
 :::
@@ -161,7 +161,7 @@ TODO: expand this section with examples of why you might do these things.
 FieldArgs keeps track of the arguments/input fields that you `.get()`,
 `.getRaw()` or `.apply()`, and should there be any left unaccessed that have an
 `applyPlan` method, these will automatically be called passing the field plan
-resolvers resulting step as the argument.
+resolver's resulting step as the argument.
 
 This, for example, allows you to associate the "first" behavior with the
 argument rather than the plan resolver, such that you could share the


### PR DESCRIPTION
This commit adds two apostrophes in plan-resolvers.md. I am fairly certain, but not 100% certain, that the 2nd usage is a possessive.